### PR TITLE
Added "sudo" to voice_esptool command

### DIFF
--- a/PlatformIO/deploy.sh
+++ b/PlatformIO/deploy.sh
@@ -23,7 +23,7 @@ else
     cp .pio/build/esp32dev/partitions.bin .
     echo "Loading firmware: $FIRMWARE to $1"
     echo ""
-    tar cf - *.bin | ssh pi@$1 'tar xf - -C /tmp;sudo voice_esp32_reset;voice_esptool --chip esp32 --port /dev/ttyS0 --baud 1500000 --before default_reset --after hard_reset write_flash -u --flash_mode dio --flash_freq 40m --flash_size detect 0x1000 /tmp/bootloader.bin 0x10000 /tmp/firmware.bin 0x8000 /tmp/partitions.bin'
+    tar cf - *.bin | ssh pi@$1 'tar xf - -C /tmp;sudo voice_esp32_reset;sudo voice_esptool --chip esp32 --port /dev/ttyS0 --baud 1500000 --before default_reset --after hard_reset write_flash -u --flash_mode dio --flash_freq 40m --flash_size detect 0x1000 /tmp/bootloader.bin 0x10000 /tmp/firmware.bin 0x8000 /tmp/partitions.bin'
     echo "done"
     echo ""
     echo "[SUCCESS] Please disconnect your MatrixVoice from the RaspberryPi and reconnect it alone for future OTA updates."


### PR DESCRIPTION
`voice_esptool` also requires sudo access to be able to write to the device, otherwise errors like this will popup:

```
Traceback (most recent call last):
  File "/usr/local/bin/esptool.py", line 3969, in <module>
esptool.py v3.0
Serial port /dev/ttyS0
    _main()
  File "/usr/local/bin/esptool.py", line 3962, in _main
    main()
  File "/usr/local/bin/esptool.py", line 3551, in main
    esp = chip_class(each_port, initial_baud, args.trace)
  File "/usr/local/bin/esptool.py", line 271, in __init__
    self._port = serial.serial_for_url(port)
  File "/usr/local/lib/python2.7/dist-packages/serial/__init__.py", line 90, in serial_for_url
    instance.open()
  File "/usr/local/lib/python2.7/dist-packages/serial/serialposix.py", line 325, in open
    raise SerialException(msg.errno, "could not open port {}: {}".format(self._port, msg))
serial.serialutil.SerialException: [Errno 13] could not open port /dev/ttyS0: [Errno 13] Permission denied: '/dev/ttyS0'
```