### PR TITLE
Add logic to scan for strongest AP + UI improvement

### DIFF
--- a/PlatformIO/load_settings.py
+++ b/PlatformIO/load_settings.py
@@ -48,6 +48,9 @@ if os.path.isfile(settings):
 
         staticIp = True
 
+    if ("scanStrongestAP" in config[sectionWifi]) :
+        cpp_defines.append(("SCAN_STRONGEST_AP", "\\\"" + config[sectionWifi]["scanStrongestAP"] + "\\\""))
+
     env.Append(CPPDEFINES=cpp_defines)
 
     if (config[sectionOta]["method"] == "upload") :

--- a/PlatformIO/settings.ini.example
+++ b/PlatformIO/settings.ini.example
@@ -8,6 +8,7 @@ device_type=0
 [Wifi]
 ssid=SSID
 password=password
+;scanStrongestAP=true ; use if device connects to a non-optimal AP
 
 ;uncomment next 4 lines and fill with your own values if you want to use a static ip address
 ;ip=192.168.xxx.xxx

--- a/PlatformIO/src/General.hpp
+++ b/PlatformIO/src/General.hpp
@@ -191,6 +191,9 @@ String processor(const String& var){
   if (var == "GAIN") {
       return String(config.gain);
   }
+  if (var == "SITEID") {
+      return SITEID;
+  }
   return String();
 }
 

--- a/PlatformIO/src/index_html.h
+++ b/PlatformIO/src/index_html.h
@@ -3,7 +3,7 @@ const char index_html[] PROGMEM = R"=====(
 <!DOCTYPE html>
 <html>
 <head>
-<title>Satellite Configuration</title>
+<title>Satellite Configuration - %SITEID%</title>
 <meta http-equiv="content-type" content="text/html; charset=ISO-8859-1">
 <style>
 * {box-sizing: border-box;}


### PR DESCRIPTION
When your wifi is made of several APs then need to have special logic to make sure the closest (strongest) AP is used.

Also, add satellite id to the title of the Web UI. Useful when you have several sats open in parallel tabs.