### PR TITLE
Potential fix for #53 and support for ESP32 A1S v2.3 with ES8388

### DIFF
--- a/PlatformIO/platformio.ini
+++ b/PlatformIO/platformio.ini
@@ -13,21 +13,20 @@ build_flags =
    '-DFIXED_POINT=1'
    '-DOUTSIDE_SPEEX=1'
    
-[env:esp32dev]
+[env]
 extra_scripts = pre:load_settings.py
 platform = espressif32
-upload_speed = 115200
+upload_speed = 921000
 board = esp32dev
 framework = arduino
 board_build.partitions  = ../OTABuilder/partitions_two_ota.csv
 build_flags = ${common.build_flags}
-monitor_speed = 115200
+monitor_speed = 921000
 monitor_filters = esp32_exception_decoder
 
 ;This is where you can add dependencies of your device.
 lib_deps =
    https://github.com/matrix-io/matrixio_hal_esp32.git
-   https://github.com/Locoduino/RingBuffer.git
    https://github.com/marvinroger/async-mqtt-client.git
    https://github.com/me-no-dev/AsyncTCP.git
    https://github.com/knolleary/pubsubclient.git
@@ -36,3 +35,23 @@ lib_deps =
    m5stack/M5Atom
    fastled/FastLED
    yveaux/AC101 @ ^0.0.1
+
+
+[env:esp32dev]
+
+;supported: M5ATOMECHO=0, MATRIXVOICE=1, AUDIOKIT=2, INMP441=3, INMP441MAX98357A=4
+
+[env:m5atomecho]
+build_flags = ${env.build_flags} -DPI_DEVICE_TYPE=0
+
+[env:matrixvoice]
+build_flags = ${env.build_flags} -DPI_DEVICE_TYPE=1
+
+[env:audiokit]
+build_flags = ${env.build_flags} -DPI_DEVICE_TYPE=2
+
+[env:inmp441]
+build_flags = ${env.build_flags} -DPI_DEVICE_TYPE=3
+
+[env:inmp441Mmax98357a]
+build_flags = ${env.build_flags} -DPI_DEVICE_TYPE=4

--- a/PlatformIO/src/Esp32RingBuffer.h
+++ b/PlatformIO/src/Esp32RingBuffer.h
@@ -1,0 +1,127 @@
+#pragma once
+#include <Arduino.h>
+#include <freertos/ringbuf.h>
+
+
+/**
+ * @brief A ringbuffer class based on the ESP32 FreeRTOS ringbuffer implementation
+ * 
+ * The main use case is to convert a stream buffer (typically bytes) to a larger fixed item
+ * size (such as 16bit samples).
+ * 
+ * Pushing into the buffer can be done on the granularity of the ET item size, 
+ * popping returns always a full output item.  
+ * 
+ * The implementation is multi-core and multi-thread safe. Use methods ...FromISR
+ * in an interrupt service routine. 
+ */
+template <
+    typename IT,
+    typename OT,
+    size_t S>
+
+class Esp32RingBuffer
+{
+    RingbufHandle_t rbh;
+
+public:
+    Esp32RingBuffer()
+    {
+        static_assert((sizeof(OT) % sizeof(IT)) == 0, "sizeof of OT must be a multiple of sizeof of ET");
+        rbh = xRingbufferCreate(S * sizeof(OT), RINGBUF_TYPE_BYTEBUF);
+    }
+
+
+    /* Push an input item to the end of the buffer */
+    bool push(const IT inElement)
+    {
+        return pdTRUE == xRingbufferSend(rbh, &inElement, sizeof(IT), pdMS_TO_TICKS(10));
+    }
+    
+    /* Push an item array to the end of the buffer */
+    bool push(const IT *const inElement_p, size_t len = 1) 
+    {
+        return pdTRUE == xRingbufferSend(rbh, inElement_p, sizeof(IT)*len, pdMS_TO_TICKS(10));
+    }
+
+    /* Pop the data at the beginning of the buffer */
+    bool pop(OT &outElement)
+    {
+        bool retval = false;
+        size_t item_size;
+        if (size() >= sizeof(OT))
+        {
+            OT *item_p = static_cast<OT *>(xRingbufferReceiveUpTo(rbh, &item_size, pdMS_TO_TICKS(100), sizeof(OT)));
+            if (item_p != NULL)
+            {
+                if (item_size != sizeof(OT))
+                {
+                    Serial.println("Did not receive enough data, this should not happen");
+                }
+                else
+                {
+                    outElement = *item_p;
+                    retval = true;
+                }
+                vRingbufferReturnItem(rbh, item_p);
+            }
+        }
+        return retval;
+    }
+
+    /* Push an input item to the end of the buffer from within an interrupt service routine */
+    bool pushFromISR(const IT inElement)
+    {
+        return pdTRUE == xRingbufferSendFromISR(rbh, &inElement, sizeof(IT), pdMS_TO_TICKS(10));
+    }
+
+    /* Push an input item array to the end of the buffer from within an interrupt service routine */
+    bool pushFromISR(const IT *const inElement_p, size_t len = 1) 
+    {
+        return pdTRUE == xRingbufferSendFromISR(rbh, inElement_p, sizeof(IT)*len, pdMS_TO_TICKS(10));
+    }
+
+    /* Pop the data from the beginning of the buffer from within an interrupt service routine */
+    bool popFromISR(OT &outElement)
+    {
+        bool retval = false;
+        size_t item_size;
+        if (size() >= sizeof(OT))
+        {
+            OT *item_p = static_cast<OT *>(xRingbufferReceiveUpToFromISR(rbh, &item_size, sizeof(OT)));
+            if (item_p != NULL)
+            {
+                if (item_size != sizeof(OT))
+                {
+                    Serial.println("Did not receive enough data, this should not happen");
+                }
+                else
+                {
+                    outElement = *item_p;
+                    retval = true;
+                }
+                vRingbufferReturnItemFromISR(rbh, item_p);
+            }
+        }
+        return retval;
+    }
+
+    /* Return true if the buffer is full */
+    bool isFull() { return xRingbufferGetCurFreeSize(rbh) == 0; }
+
+    /* Return true if the buffer is empty */
+    bool isEmpty() { return xRingbufferGetCurFreeSize(rbh) == xRingbufferGetMaxItemSize(rbh); }
+    
+    /* Reset the buffer  to an empty state */
+    void clear()
+    { /* not implemented */
+    }
+    /* return the used size of the buffer in bytes */
+    size_t size() { return xRingbufferGetMaxItemSize(rbh) - xRingbufferGetCurFreeSize(rbh); }
+
+    /* return the maximum size of the buffer in bytes*/
+    size_t maxSize() { return xRingbufferGetMaxItemSize(rbh); }
+
+    /* return the free size of the buffer in bytes*/
+    size_t freeSize() { return xRingbufferGetMaxItemSize(rbh); }
+};

--- a/PlatformIO/src/General.hpp
+++ b/PlatformIO/src/General.hpp
@@ -3,11 +3,11 @@
 #include <WiFi.h>
 #include <AsyncMqttClient.h>
 #include <PubSubClient.h>
-#include "RingBuf.h"
 #include "SPIFFS.h"
 #include "ESPAsyncWebServer.h"
 #include <ArduinoJson.h>
 #include "index_html.h"
+#include "Esp32RingBuffer.h"
 
 const int PLAY = BIT0;
 const int STREAM = BIT1;
@@ -70,7 +70,7 @@ std::string restartTopic = config.siteid + std::string("/restart");
 AsyncMqttClient asyncClient; 
 WiFiClient net;
 PubSubClient audioServer(net); 
-RingBuf<uint8_t, 60000> audioData;
+Esp32RingBuffer<uint8_t, uint16_t, (1U << 15)> audioData;
 long message_size = 0;
 int queueDelay = 10;
 int sampleRate = 16000;
@@ -145,8 +145,6 @@ XT_Wav_Class::XT_Wav_Class(const unsigned char *WavData) {
         ofs += longword(WavData, ofs + 4) + 8;
     }
 }
-
-uint8_t WaveData[44];
 
 // this function supplies template variables to the template engine
 String processor(const String& var){

--- a/PlatformIO/src/Satellite.cpp
+++ b/PlatformIO/src/Satellite.cpp
@@ -104,6 +104,11 @@
 #define INMP441 3
 #define INMP441MAX98357A 4
 
+#ifdef PI_DEVICE_TYPE
+#undef DEVICE_TYPE
+#define DEVICE_TYPE PI_DEVICE_TYPE
+#endif
+
 
 // This is where you can include your device, make sure to create a *device
 // The *device is used to call methods
@@ -122,13 +127,15 @@
 #elif DEVICE_TYPE == INMP441MAX98357A
   #include "devices/Inmp441Max98357a.hpp"
   Inmp441Max98357a *device = new Inmp441Max98357a();
+#else
+  #error DEVICE_TYPE is out of range  
 #endif
 
 #include <General.hpp>
 #include <StateMachine.hpp>
 
 void setup() {
-  Serial.begin(115200);
+  Serial.begin(921000);
   Serial.println("Booting");
 
   if (wbSemaphore == NULL)  // Not yet been created?

--- a/PlatformIO/src/devices/AudioKit.hpp
+++ b/PlatformIO/src/devices/AudioKit.hpp
@@ -1,52 +1,189 @@
 #include <driver/i2s.h>
 #include <AC101.h>
+#include <Wire.h>
 
 // I2S pins
-#define IIS_SCLK 27
-#define IIS_WSLC 26
-#define IIS_DSIN 25
-#define IIS_DSOU 35
+#define CONFIG_I2S_BCK_PIN 27
+#define CONFIG_I2S_LRCK_PIN 26
+#define CONFIG_I2S_DATA_PIN 25
+#define CONFIG_I2S_DATA_IN_PIN 35
 
-#define CONFIG_I2S_BCK_PIN IIS_SCLK
-#define CONFIG_I2S_LRCK_PIN IIS_WSLC
-#define CONFIG_I2S_DATA_PIN IIS_DSIN
-#define CONFIG_I2S_DATA_IN_PIN IIS_DSOU
+#define ES_CONFIG_I2S_BCK_PIN 5
+#define ES_CONFIG_I2S_LRCK_PIN 25
+#define ES_CONFIG_I2S_DATA_PIN 26
+#define ES_CONFIG_I2S_DATA_IN_PIN 35
 
 // AC101 I2C pins
 #define IIC_CLK 32
 #define IIC_DATA 33
 
+#define ES_IIC_CLK 23
+#define ES_IIC_DATA 18
+
 // amplifier enable pin
 #define GPIO_PA_EN GPIO_NUM_21
 #define GPIO_SEL_PA_EN GPIO_SEL_21
 
-// LEDs
+// Audiokit LEDs
 #define LED_D4 GPIO_NUM_19
 #define LED_D5 GPIO_NUM_22
 // alias
 #define LED_WIFI LED_D5
 #define LED_STREAM LED_D4
 
-// Buttons
+// Audiokit Buttons
 #define KEY1_GPIO GPIO_NUM_36
 #define KEY2_GPIO GPIO_NUM_13
-#define KEY3_GPIO GPIO_NUM_19
-#define KEY4_GPIO GPIO_NUM_23
-#define KEY5_GPIO GPIO_NUM_18
-#define KEY6_GPIO GPIO_NUM_5
+#define KEY3_GPIO GPIO_NUM_19 // also LED D4
+#define KEY4_GPIO GPIO_NUM_23 // do not use on V2.3 -> I2S
+#define KEY5_GPIO GPIO_NUM_18 // do not use on V2.3 -> I2S
+#define KEY6_GPIO GPIO_NUM_5  // do not use on V2.3 -> I2S
 // alias
-#define KEY_LISTEN KEY4_GPIO
-// #define KEY_VOL_UP KEY5_GPIO
-// #define KEY_VOL_DOWN KEY6_GPIO
+#define KEY_LISTEN KEY1_GPIO
+//#define KEY_VOL_UP KEY5_GPIO
+//#define KEY_VOL_DOWN KEY6_GPIO
 
 #define SPEAKER_I2S_NUMBER I2S_NUM_0
 
+#ifndef _ES8388_REGISTERS_H
+#define _ES8388_REGISTERS_H
+
+#define ES8388_ADDR 0x10
+/* ES8388 register */
+#define ES8388_CONTROL1 0x00
+#define ES8388_CONTROL2 0x01
+#define ES8388_CHIPPOWER 0x02
+#define ES8388_ADCPOWER 0x03
+#define ES8388_DACPOWER 0x04
+#define ES8388_CHIPLOPOW1 0x05
+#define ES8388_CHIPLOPOW2 0x06
+#define ES8388_ANAVOLMANAG 0x07
+#define ES8388_MASTERMODE 0x08
+
+/* ADC */
+#define ES8388_ADCCONTROL1 0x09
+#define ES8388_ADCCONTROL2 0x0a
+#define ES8388_ADCCONTROL3 0x0b
+#define ES8388_ADCCONTROL4 0x0c
+#define ES8388_ADCCONTROL5 0x0d
+#define ES8388_ADCCONTROL6 0x0e
+#define ES8388_ADCCONTROL7 0x0f
+#define ES8388_ADCCONTROL8 0x10
+#define ES8388_ADCCONTROL9 0x11
+#define ES8388_ADCCONTROL10 0x12
+#define ES8388_ADCCONTROL11 0x13
+#define ES8388_ADCCONTROL12 0x14
+#define ES8388_ADCCONTROL13 0x15
+#define ES8388_ADCCONTROL14 0x16
+
+/* DAC */
+#define ES8388_DACCONTROL1 0x17
+#define ES8388_DACCONTROL2 0x18
+#define ES8388_DACCONTROL3 0x19
+#define ES8388_DACCONTROL4 0x1a
+#define ES8388_DACCONTROL5 0x1b
+#define ES8388_DACCONTROL6 0x1c
+#define ES8388_DACCONTROL7 0x1d
+#define ES8388_DACCONTROL8 0x1e
+#define ES8388_DACCONTROL9 0x1f
+#define ES8388_DACCONTROL10 0x20
+#define ES8388_DACCONTROL11 0x21
+#define ES8388_DACCONTROL12 0x22
+#define ES8388_DACCONTROL13 0x23
+#define ES8388_DACCONTROL14 0x24
+#define ES8388_DACCONTROL15 0x25
+#define ES8388_DACCONTROL16 0x26
+#define ES8388_DACCONTROL17 0x27
+#define  ES8388_DACCONTROL18 0x28
+#define ES8388_DACCONTROL19 0x29
+#define ES8388_DACCONTROL20 0x2a
+#define ES8388_DACCONTROL21 0x2b
+#define ES8388_DACCONTROL22 0x2c
+#define ES8388_DACCONTROL23 0x2d
+#define ES8388_DACCONTROL24 0x2e
+#define ES8388_DACCONTROL25 0x2f
+#define ES8388_DACCONTROL26 0x30
+#define ES8388_DACCONTROL27 0x31
+#define ES8388_DACCONTROL28 0x32
+#define ES8388_DACCONTROL29 0x33
+#define ES8388_DACCONTROL30 0x34
+
+#endif
+
+static bool es_write_reg(uint8_t slave_add, uint8_t reg_add, uint8_t data)
+{
+    Wire.beginTransmission(slave_add);
+    Wire.write(reg_add);
+    Wire.write(data);
+    return Wire.endTransmission() == 0;
+}
+
+static esp_err_t es8388_init()
+{
+    esp_err_t res = ESP_OK;
+
+    /* mute DAC during setup, power up all systems, slave mode */
+    res |= es_write_reg(ES8388_ADDR, ES8388_DACCONTROL3, 0x04);
+    res |= es_write_reg(ES8388_ADDR, ES8388_CONTROL2, 0x50);
+    res |= es_write_reg(ES8388_ADDR, ES8388_CHIPPOWER, 0x00);
+    res |= es_write_reg(ES8388_ADDR, ES8388_MASTERMODE, 0x00);
+
+    /* power up DAC and enable LOUT1+2 / ROUT1+2, ADC sample rate = DAC sample rate */
+    res |= es_write_reg(ES8388_ADDR, ES8388_DACPOWER, 0x3e);
+    res |= es_write_reg(ES8388_ADDR, ES8388_CONTROL1, 0x12);
+
+    /* DAC I2S setup: 16 bit word length, I2S format; MCLK / Fs = 256*/
+    res |= es_write_reg(ES8388_ADDR, ES8388_DACCONTROL1, 0x18);
+    res |= es_write_reg(ES8388_ADDR, ES8388_DACCONTROL2, 0x02);
+
+    /* DAC to output route mixer configuration: ADC MIX TO OUTPUT */
+    res |= es_write_reg(ES8388_ADDR, ES8388_DACCONTROL16, 0x1B);
+    res |= es_write_reg(ES8388_ADDR, ES8388_DACCONTROL17, 0x90);
+    res |= es_write_reg(ES8388_ADDR, ES8388_DACCONTROL20, 0x90);
+
+    /* DAC and ADC use same LRCK, enable MCLK input; output resistance setup */
+    res |= es_write_reg(ES8388_ADDR, ES8388_DACCONTROL21, 0x80);
+    res |= es_write_reg(ES8388_ADDR, ES8388_DACCONTROL23, 0x00);
+
+    /* DAC volume control: 0dB (maximum, unattenuated)  */
+    res |= es_write_reg(ES8388_ADDR, ES8388_DACCONTROL5, 0x00);
+    res |= es_write_reg(ES8388_ADDR, ES8388_DACCONTROL4, 0x00);
+
+    /* power down ADC while configuring; volume: +9dB for both channels */
+    res |= es_write_reg(ES8388_ADDR, ES8388_ADCPOWER, 0xff);
+    res |= es_write_reg(ES8388_ADDR, ES8388_ADCCONTROL1, 0x88); // +24db
+
+    /* select LINPUT2 / RINPUT2 as ADC input; stereo; 16 bit word length, format right-justified, MCLK / Fs = 256 */
+    res |= es_write_reg(ES8388_ADDR, ES8388_ADCCONTROL2, 0xf0); // 50
+    res |= es_write_reg(ES8388_ADDR, ES8388_ADCCONTROL3, 0x80); // 00
+    res |= es_write_reg(ES8388_ADDR, ES8388_ADCCONTROL4, 0x0e);
+    res |= es_write_reg(ES8388_ADDR, ES8388_ADCCONTROL5, 0x02);
+
+    /* set ADC volume */
+    res |= es_write_reg(ES8388_ADDR, ES8388_ADCCONTROL8, 0x20);
+    res |= es_write_reg(ES8388_ADDR, ES8388_ADCCONTROL9, 0x20);
+
+    /* set LOUT1 / ROUT1 volume: 0dB (unattenuated) */
+    res |= es_write_reg(ES8388_ADDR, ES8388_DACCONTROL24, 0x1e);
+    res |= es_write_reg(ES8388_ADDR, ES8388_DACCONTROL25, 0x1e);
+
+    /* set LOUT2 / ROUT2 volume: 0dB (unattenuated) */
+    res |= es_write_reg(ES8388_ADDR, ES8388_DACCONTROL26, 0x1e);
+    res |= es_write_reg(ES8388_ADDR, ES8388_DACCONTROL27, 0x1e);
+
+    /* power up and enable DAC; power up ADC (no MIC bias) */
+    res |= es_write_reg(ES8388_ADDR, ES8388_DACPOWER, 0x3c);
+    res |= es_write_reg(ES8388_ADDR, ES8388_DACCONTROL3, 0x00);
+    res |= es_write_reg(ES8388_ADDR, ES8388_ADCPOWER, 0x00);
+
+    return res;
+}
 class AudioKit : public Device
 {
 public:
     AudioKit();
     void init();
-    void updateLeds(int colors);
+    void updateColors(int colors);
 
     void setReadMode();
     void setWriteMode(int sampleRate, int bitDepth, int numChannels);
@@ -66,23 +203,40 @@ public:
 private:
     void InitI2SSpeakerOrMic(int mode);
     AC101 ac;
+    bool is_es = false;
+    bool is_2chan_out = false;
 };
 
 AudioKit::AudioKit(){};
 
 void AudioKit::init()
 {
-    Serial.printf("Connect to AC101 codec... ");
-    while (!ac.begin(IIC_DATA, IIC_CLK))
+    Serial.print("Connect to Codec... ");
+
+    Wire.begin(ES_IIC_DATA, ES_IIC_CLK);
+    Wire.beginTransmission(ES8388_ADDR);
+    is_es = Wire.endTransmission() == 0;
+
+    if (is_es)
     {
-        Serial.printf("Failed!\n");
-        delay(1000);
+        Serial.println("found ES8388");
+        es8388_init();
     }
-    ac.SetMode(AC101::MODE_ADC_DAC);
+    else
+    {
+        Serial.println("looking for AC101...");
+        while (!ac.begin(IIC_DATA, IIC_CLK))
+        {
+            Serial.printf("failed!\n");
+            delay(1000);
+        }
+        ac.SetMode(AC101::MODE_ADC_DAC);
+    }
 
     // LEDs
     pinMode(LED_STREAM, OUTPUT); // active low
     pinMode(LED_WIFI, OUTPUT);   // active low
+    
     digitalWrite(LED_STREAM, HIGH);
     digitalWrite(LED_WIFI, HIGH);
 
@@ -95,8 +249,10 @@ void AudioKit::init()
     // pinMode(KEY_VOL_DOWN, INPUT_PULLUP);
 };
 
-void AudioKit::updateLeds(int colors)
+void AudioKit::updateColors(int colors)
 {
+    //Serial.printf("updateColors(%d)\n", colors);
+
     // turn off LEDs
     digitalWrite(LED_STREAM, HIGH);
     digitalWrite(LED_WIFI, HIGH);
@@ -122,18 +278,19 @@ void AudioKit::updateLeds(int colors)
 
 void AudioKit::InitI2SSpeakerOrMic(int mode)
 {
+    Serial.printf("InitI2SSpeakerOrMic -> %s\n", mode == MODE_MIC ? "Mic" : "Speaker");
     esp_err_t err = ESP_OK;
 
     i2s_driver_uninstall(SPEAKER_I2S_NUMBER);
     i2s_config_t i2s_config = {
         .mode = (i2s_mode_t)(I2S_MODE_MASTER),
         .sample_rate = 16000,
-        .bits_per_sample = I2S_BITS_PER_SAMPLE_16BIT, // is fixed at 12bit, stereo, MSB
+        .bits_per_sample = I2S_BITS_PER_SAMPLE_16BIT, // is fixed at 16bit, stereo, MSB
         .channel_format = I2S_CHANNEL_FMT_RIGHT_LEFT,
         .communication_format = i2s_comm_format_t(I2S_COMM_FORMAT_I2S | I2S_COMM_FORMAT_I2S_MSB),
         .intr_alloc_flags = ESP_INTR_FLAG_LEVEL1,
         .dma_buf_count = 8,
-        .dma_buf_len = 60,
+        .dma_buf_len = (((mode == MODE_MIC) ? this->readSize : this->writeSize) * (is_es ? 2 : 1)) / 4,
     };
     if (mode == MODE_MIC)
     {
@@ -149,13 +306,26 @@ void AudioKit::InitI2SSpeakerOrMic(int mode)
     err += i2s_driver_install(SPEAKER_I2S_NUMBER, &i2s_config, 0, NULL);
     i2s_pin_config_t tx_pin_config;
 
-    tx_pin_config.bck_io_num = CONFIG_I2S_BCK_PIN;
-    tx_pin_config.ws_io_num = CONFIG_I2S_LRCK_PIN;
-    tx_pin_config.data_out_num = CONFIG_I2S_DATA_PIN;
-    tx_pin_config.data_in_num = CONFIG_I2S_DATA_IN_PIN;
+    if (is_es)
+    {
+        tx_pin_config.bck_io_num = ES_CONFIG_I2S_BCK_PIN;
+        tx_pin_config.ws_io_num = ES_CONFIG_I2S_LRCK_PIN;
+        tx_pin_config.data_out_num = ES_CONFIG_I2S_DATA_PIN;
+        tx_pin_config.data_in_num = ES_CONFIG_I2S_DATA_IN_PIN;
+    }
+    else
+    {
+        tx_pin_config.bck_io_num = CONFIG_I2S_BCK_PIN;
+        tx_pin_config.ws_io_num = CONFIG_I2S_LRCK_PIN;
+        tx_pin_config.data_out_num = CONFIG_I2S_DATA_PIN;
+        tx_pin_config.data_in_num = CONFIG_I2S_DATA_IN_PIN;
+    }
 
     err += i2s_set_pin(SPEAKER_I2S_NUMBER, &tx_pin_config);
-    err += i2s_set_clk(SPEAKER_I2S_NUMBER, 16000, I2S_BITS_PER_SAMPLE_16BIT, I2S_CHANNEL_MONO);
+    err += i2s_set_clk(SPEAKER_I2S_NUMBER, 16000, I2S_BITS_PER_SAMPLE_16BIT, I2S_CHANNEL_STEREO);
+
+    PIN_FUNC_SELECT(PERIPHS_IO_MUX_GPIO0_U, FUNC_GPIO0_CLK_OUT1);
+    WRITE_PERI_REG(PIN_CTRL, 0xFFF0);
 
     return;
 }
@@ -169,7 +339,16 @@ void AudioKit::setWriteMode(int sampleRate, int bitDepth, int numChannels)
     }
     if (sampleRate > 0)
     {
-        i2s_set_clk(SPEAKER_I2S_NUMBER, sampleRate, static_cast<i2s_bits_per_sample_t>(bitDepth), static_cast<i2s_channel_t>(numChannels));
+        if (is_es)
+        {
+            // es8388 requires stereo i2s
+            i2s_set_clk(SPEAKER_I2S_NUMBER, sampleRate, static_cast<i2s_bits_per_sample_t>(bitDepth), I2S_CHANNEL_STEREO);
+        }
+        else
+        {
+            i2s_set_clk(SPEAKER_I2S_NUMBER, sampleRate, static_cast<i2s_bits_per_sample_t>(bitDepth), static_cast<i2s_channel_t>(numChannels));
+        }
+        is_2chan_out = numChannels == 2;
     }
 }
 
@@ -184,14 +363,52 @@ void AudioKit::setReadMode()
 
 void AudioKit::writeAudio(uint8_t *data, size_t size, size_t *bytes_written)
 {
-    i2s_write(SPEAKER_I2S_NUMBER, data, size, bytes_written, portMAX_DELAY);
+    if (is_2chan_out || !is_es)
+    {
+        i2s_write(SPEAKER_I2S_NUMBER, data, size, bytes_written, portMAX_DELAY);      
+    }
+    else
+    {
+        uint16_t data2[size];
+        uint16_t *data1 = (uint16_t *)data;
+
+        for (int idx = 0; idx < size / 2; idx++)
+        {
+            data2[2 * idx] = data1[idx];
+            data2[2 * idx + 1] = data1[idx];
+            
+        }
+
+        i2s_write(SPEAKER_I2S_NUMBER, data2, 2 * size, bytes_written, portMAX_DELAY);
+        *bytes_written /= 2;
+    }
+    *bytes_written = size;
 }
 
 bool AudioKit::readAudio(uint8_t *data, size_t size)
 {
+
     size_t byte_read;
-    i2s_read(SPEAKER_I2S_NUMBER, data, size, &byte_read, (100 / portTICK_RATE_MS));
-    return true;
+
+    if (!is_es)
+    {
+        i2s_read(SPEAKER_I2S_NUMBER, data, size, &byte_read, (100 / portTICK_RATE_MS));
+    }
+    else
+    {
+        uint16_t data2[size];
+        uint16_t *data1 = (uint16_t *)data;
+
+        i2s_read(SPEAKER_I2S_NUMBER, data2, 2 * size, &byte_read, (100 / portTICK_RATE_MS));
+
+        for (size_t idx = 0; idx < size / 2; idx++)
+        {
+            data1[idx] = data2[idx * 2];
+        }
+        byte_read /= 2;
+    }
+
+    return byte_read == size;
 }
 
 void AudioKit::muteOutput(bool mute)
@@ -204,8 +421,14 @@ void AudioKit::setVolume(uint16_t volume)
     // volume is 0 to 100, needs to be 0 to 63
     const uint8_t vol = (uint8_t)(volume / 100.0f * 63.0f);
 
-    ac.SetVolumeHeadphone(vol);
-    ac.SetVolumeSpeaker(vol);
+    if (is_es)
+    {
+    }
+    else
+    {
+        ac.SetVolumeHeadphone(vol);
+        ac.SetVolumeSpeaker(vol);
+    }
 }
 
 bool AudioKit::isHotwordDetected()


### PR DESCRIPTION
I happened to receive new version of the ESP32 A1S which sports a ES8388 (like the LyraT) instead of the AC101 in previous version of the ESP32 A1S. This pull request adds support for my hardware. In principle this should also support the A1S with AC101 but I have no way to check this.

I also encountered significant problems with audio stream even with 16k/mono/16bit like discussed in #53 . I identified the Arduino RingBuffer library as main part of the problem and replaced it with a wrapper for the ESP32 multi-core/multi-thread safe ESP32 IDF FreeRTOS ringbuffer. This improved things a lot for me. Stereo stream w/ 44.1k 16 bit almost works most of the time. And lower bitrates are more or less flawless. It seems that the WiFi / MQTT processing is now the limiting factor. If the WiFi connections gets worse (like by shielding the antenna), it also affects the sound quality.
 
To reduce problems due to slow serial output I changed the serial monitor speed to 92100, works without problems for me. Also updated the upload speed to this value. 

In order to run builds for all supported device types from within PlatformIO  I added an override (PI_DEVICE_TYPE) for the DEVICE_TYPE define done by the python script. All other settings are shared between all builds as before. If PI_DEVICE_TYPE is not defined, code works as before.

Have a look and give me feedback. Of course, I would like to see these changes integrated in the main repository and I am willing to make changes to make it easy for you to accept this PR.


