### PR TITLE
ES8388 changes, audio switching and web server improvement, misc changes

### DIFF
--- a/PlatformIO/src/StateMachine.hpp
+++ b/PlatformIO/src/StateMachine.hpp
@@ -371,14 +371,16 @@ void handle_playBytes(const std::string& topicstr, uint8_t *payload, size_t len,
     message_size = total;
     audioData.clear();
     XT_Wav_Class Message((const uint8_t *)payload);
-    Serial.printf("Samplerate: %d, Channels: %d, Format: %d, Bits per Sample: %d\r\n", (int)Message.SampleRate, (int)Message.NumChannels, (int)Message.Format, (int)Message.BitsPerSample);
-    sampleRate = (int)Message.SampleRate;
-    numChannels = (int)Message.NumChannels;
-    bitDepth = (int)Message.BitsPerSample;
-    queueDelay = ((int)Message.SampleRate * (int)Message.NumChannels * (int)Message.BitsPerSample) / 1000;
+    
+    sampleRate = Message.SampleRate;
+    numChannels = Message.NumChannels;
+    bitDepth = Message.BitsPerSample;
+    offset = Message.DataStart;
+
+    Serial.printf("Samplerate: %d, Channels: %d, Format: %d, Bits per Sample: %d, Start: %d\r\n", sampleRate, numChannels, (int)Message.Format, bitDepth, offset);
+    queueDelay = (sampleRate * numChannels * bitDepth) / 1000;
     //delay *= 2;
     //Serial.printf("Delay %d\n", (int)queueDelay);
-    offset = 44;
   }
 
   push_i2s_data((uint8_t *)&payload[offset], len - offset);

--- a/PlatformIO/src/device.h
+++ b/PlatformIO/src/device.h
@@ -22,7 +22,8 @@ enum DeviceMode {
 //The Matrix Voice has an jack and a speaker
 enum AmpOut {
   AMP_OUT_SPEAKERS = 0,
-  AMP_OUT_HEADPHONE = 1
+  AMP_OUT_HEADPHONE = 1,
+  AMP_OUT_BOTH = 2,
 };
 
 class Device {
@@ -52,6 +53,9 @@ class Device {
     virtual void setGain(uint16_t gain) {};
     //You can use this method to activated the hotword state (i.e. a hardware button)
     virtual bool isHotwordDetected() {return false;};
+
+    // how many different output configurations does this devices support (1 = single output channel, 2 = 2 output channels, i.e. speaker or headphone, 3 = speaker, headphone, speaker + headphone)
+    virtual int numAmpOutConfigurations() { return 2; };
     //
     //You can override these in your device
     int readSize = 256;

--- a/PlatformIO/src/device.h
+++ b/PlatformIO/src/device.h
@@ -20,7 +20,7 @@ enum DeviceMode {
 
 //Devices can have several outputs. 
 //The Matrix Voice has an jack and a speaker
-enum {
+enum AmpOut {
   AMP_OUT_SPEAKERS = 0,
   AMP_OUT_HEADPHONE = 1
 };

--- a/PlatformIO/src/devices/AudioKit.hpp
+++ b/PlatformIO/src/devices/AudioKit.hpp
@@ -6,6 +6,7 @@
 #include <AC101.h>
 #include <Wire.h>
 #include <IndicatorLight.h>
+#include "ES8388Control.h"
 
 // I2S pins
 #define CONFIG_I2S_BCK_PIN 27
@@ -53,270 +54,6 @@
 
 #define SPEAKER_I2S_NUMBER I2S_NUM_0
 
-#ifndef _ES8388_REGISTERS_H
-#define _ES8388_REGISTERS_H
-
-#define ES8388_ADDR 0x10
-
-/* ES8388 register */
-#define ES8388_CONTROL1 0x00
-#define ES8388_CONTROL2 0x01
-#define ES8388_CHIPPOWER 0x02
-#define ES8388_ADCPOWER 0x03
-#define ES8388_DACPOWER 0x04
-#define ES8388_CHIPLOPOW1 0x05
-#define ES8388_CHIPLOPOW2 0x06
-#define ES8388_ANAVOLMANAG 0x07
-#define ES8388_MASTERMODE 0x08
-
-/* ADC */
-#define ES8388_ADCCONTROL1 0x09
-#define ES8388_ADCCONTROL2 0x0a
-#define ES8388_ADCCONTROL3 0x0b
-#define ES8388_ADCCONTROL4 0x0c
-#define ES8388_ADCCONTROL5 0x0d
-#define ES8388_ADCCONTROL6 0x0e
-#define ES8388_ADCCONTROL7 0x0f
-#define ES8388_ADCCONTROL8 0x10
-#define ES8388_ADCCONTROL9 0x11
-#define ES8388_ADCCONTROL10 0x12
-#define ES8388_ADCCONTROL11 0x13
-#define ES8388_ADCCONTROL12 0x14
-#define ES8388_ADCCONTROL13 0x15
-#define ES8388_ADCCONTROL14 0x16
-
-/* DAC */
-#define ES8388_DACCONTROL1 0x17
-#define ES8388_DACCONTROL2 0x18
-#define ES8388_DACCONTROL3 0x19
-#define ES8388_DACCONTROL4 0x1a
-#define ES8388_DACCONTROL5 0x1b
-#define ES8388_DACCONTROL6 0x1c
-#define ES8388_DACCONTROL7 0x1d
-#define ES8388_DACCONTROL8 0x1e
-#define ES8388_DACCONTROL9 0x1f
-#define ES8388_DACCONTROL10 0x20
-#define ES8388_DACCONTROL11 0x21
-#define ES8388_DACCONTROL12 0x22
-#define ES8388_DACCONTROL13 0x23
-#define ES8388_DACCONTROL14 0x24
-#define ES8388_DACCONTROL15 0x25
-#define ES8388_DACCONTROL16 0x26
-#define ES8388_DACCONTROL17 0x27
-#define ES8388_DACCONTROL18 0x28
-#define ES8388_DACCONTROL19 0x29
-#define ES8388_DACCONTROL20 0x2a
-#define ES8388_DACCONTROL21 0x2b
-#define ES8388_DACCONTROL22 0x2c
-#define ES8388_DACCONTROL23 0x2d
-#define ES8388_DACCONTROL24 0x2e
-#define ES8388_DACCONTROL25 0x2f
-#define ES8388_DACCONTROL26 0x30
-#define ES8388_DACCONTROL27 0x31
-#define ES8388_DACCONTROL28 0x32
-#define ES8388_DACCONTROL29 0x33
-#define ES8388_DACCONTROL30 0x34
-
-#endif
-
-class ES8388
-{
-
-    bool write_reg(uint8_t slave_add, uint8_t reg_add, uint8_t data);
-    bool read_reg(uint8_t slave_add, uint8_t reg_add, uint8_t& data);
-    bool identify(int sda, int scl, uint32_t frequency);
-
-    public:
-
-    bool begin(int sda = -1, int scl = -1, uint32_t frequency = 400000U);
-
-    enum ES8388_OUT {
-    ES_MAIN,    // this is the DAC output volume (both outputs)    
-    ES_OUT1,    // this is the additional gain for OUT1
-    ES_OUT2     // this is the additional gain for OUT2 
-    };
-
-    void mute(const  ES8388_OUT out, const bool muted);
-    void volume(const  ES8388_OUT out, const uint8_t vol);
-
-};
-
-bool ES8388::write_reg(uint8_t slave_add, uint8_t reg_add, uint8_t data)
-{
-    Wire.beginTransmission(slave_add);
-    Wire.write(reg_add);
-    Wire.write(data);
-    return Wire.endTransmission() == 0;
-}
-
-bool ES8388::read_reg(uint8_t slave_add, uint8_t reg_add, uint8_t& data)
-{
-    bool retval = false;
-    Wire.beginTransmission(slave_add);
-    Wire.write(reg_add);
-    Wire.endTransmission(false);
-    Wire.requestFrom((uint16_t)slave_add, (uint8_t)1, true);
-    if (Wire.available() >= 1)
-    {
-        data = Wire.read();
-        retval = true;
-    }
-    return retval;
-}
-
-bool ES8388::begin(int sda, int scl, uint32_t frequency)
-{
-    bool res = identify(sda, scl, frequency);
-
-    if (res == true)
-    {
-
-        /* mute DAC during setup, power up all systems, slave mode */
-        res &= write_reg(ES8388_ADDR, ES8388_DACCONTROL3, 0x04);
-        res &= write_reg(ES8388_ADDR, ES8388_CONTROL2, 0x50);
-        res &= write_reg(ES8388_ADDR, ES8388_CHIPPOWER, 0x00);
-        res &= write_reg(ES8388_ADDR, ES8388_MASTERMODE, 0x00);
-
-        /* power up DAC and enable LOUT1+2 / ROUT1+2, ADC sample rate = DAC sample rate */
-        res &= write_reg(ES8388_ADDR, ES8388_DACPOWER, 0x3e);
-        res &= write_reg(ES8388_ADDR, ES8388_CONTROL1, 0x12);
-
-        /* DAC I2S setup: 16 bit word length, I2S format; MCLK / Fs = 256*/
-        res &= write_reg(ES8388_ADDR, ES8388_DACCONTROL1, 0x18);
-        res &= write_reg(ES8388_ADDR, ES8388_DACCONTROL2, 0x02);
-
-        /* DAC to output route mixer configuration: ADC MIX TO OUTPUT */
-        res &= write_reg(ES8388_ADDR, ES8388_DACCONTROL16, 0x1B);
-        res &= write_reg(ES8388_ADDR, ES8388_DACCONTROL17, 0x90);
-        res &= write_reg(ES8388_ADDR, ES8388_DACCONTROL20, 0x90);
-
-        /* DAC and ADC use same LRCK, enable MCLK input; output resistance setup */
-        res &= write_reg(ES8388_ADDR, ES8388_DACCONTROL21, 0x80);
-        res &= write_reg(ES8388_ADDR, ES8388_DACCONTROL23, 0x00);
-
-        /* DAC volume control: 0dB (maximum, unattenuated)  */
-        res &= write_reg(ES8388_ADDR, ES8388_DACCONTROL5, 0x00);
-        res &= write_reg(ES8388_ADDR, ES8388_DACCONTROL4, 0x00);
-
-        /* power down ADC while configuring; volume: +9dB for both channels */
-        res &= write_reg(ES8388_ADDR, ES8388_ADCPOWER, 0xff);
-        res &= write_reg(ES8388_ADDR, ES8388_ADCCONTROL1, 0x88); // +24db
-
-        /* select LINPUT2 / RINPUT2 as ADC input; stereo; 16 bit word length, format right-justified, MCLK / Fs = 256 */
-        res &= write_reg(ES8388_ADDR, ES8388_ADCCONTROL2, 0xf0); // 50
-        res &= write_reg(ES8388_ADDR, ES8388_ADCCONTROL3, 0x80); // 00
-        res &= write_reg(ES8388_ADDR, ES8388_ADCCONTROL4, 0x0e);
-        res &= write_reg(ES8388_ADDR, ES8388_ADCCONTROL5, 0x02);
-
-        /* set ADC volume */
-        res &= write_reg(ES8388_ADDR, ES8388_ADCCONTROL8, 0x20);
-        res &= write_reg(ES8388_ADDR, ES8388_ADCCONTROL9, 0x20);
-
-        /* set LOUT1 / ROUT1 volume: 0dB (unattenuated) */
-        res &= write_reg(ES8388_ADDR, ES8388_DACCONTROL24, 0x1e);
-        res &= write_reg(ES8388_ADDR, ES8388_DACCONTROL25, 0x1e);
-
-        /* set LOUT2 / ROUT2 volume: 0dB (unattenuated) */
-        res &= write_reg(ES8388_ADDR, ES8388_DACCONTROL26, 0x1e);
-        res &= write_reg(ES8388_ADDR, ES8388_DACCONTROL27, 0x1e);
-
-        /* power up and enable DAC; power up ADC (no MIC bias) */
-        res &= write_reg(ES8388_ADDR, ES8388_DACPOWER, 0x3c);
-        res &= write_reg(ES8388_ADDR, ES8388_DACCONTROL3, 0x00);
-        res &= write_reg(ES8388_ADDR, ES8388_ADCPOWER, 0x00);
-    }
-
-    return res;
-}
-
-/**
- * @brief (un)mute one of the two outputs or main dac output of the ES8388 by switching of the output register bits. Does not really mute the selected output, causes an attenuation. 
- * hence should be used in conjunction with appropriate volume setting. Main dac output mute does mute both outputs
- * 
- * @param out 
- * @param muted 
- */
-void ES8388::mute(const ES8388_OUT out, const bool muted)
-{
-    uint8_t reg_addr;
-    uint8_t mask_mute;
-    uint8_t mask_val;
-
-    switch(out)
-    {
-    case ES_OUT1:
-        reg_addr = ES8388_DACPOWER;
-        mask_mute =(3 << 4);
-        mask_val = muted ? 0 : mask_mute;
-        break;
-    case ES_OUT2:
-        reg_addr = ES8388_DACPOWER;
-        mask_mute =(3 << 2);
-        mask_val = muted ? 0 : mask_mute;
-        break;
-    case ES_MAIN: 
-    default:
-        reg_addr = ES8388_DACCONTROL3;
-        mask_mute = 1 << 2;
-        mask_val = muted ? mask_mute : 0;
-        break;
-    }
-
-    uint8_t reg;
-    if (read_reg(ES8388_ADDR, reg_addr, reg))
-    {
-        reg = (reg & ~mask_mute) | (mask_val & mask_mute);
-        write_reg(ES8388_ADDR, reg_addr, reg);
-    }
-}
-
-/**
- * @brief Set volume gain for the main dac, or for one of the two output channels. Final gain = main gain + out channel gain 
- * 
- * @param out which gain setting to control
- * @param vol 0-100 (100 is max)
- */
-void ES8388::volume(const ES8388_OUT out, const uint8_t vol)
-{
-    const uint32_t max_vol = 100; // max input volume value 
-    
-    const int32_t max_vol_val = out == ES8388_OUT::ES_MAIN? 96 : 0x21; // max register value for ES8388 out volume
-
-
-    uint8_t lreg = 0, rreg = 0;
-
-    switch (out)
-    {
-        case ES_MAIN: lreg = ES8388_DACCONTROL4; rreg = ES8388_DACCONTROL5; break;
-        case ES_OUT1: lreg = ES8388_DACCONTROL24; rreg = ES8388_DACCONTROL25; break;
-        case ES_OUT2: lreg = ES8388_DACCONTROL26; rreg = ES8388_DACCONTROL27; break;
-    }
-
-    uint8_t vol_val = vol > max_vol? max_vol_val : (max_vol_val * vol) / max_vol;
-
-    // main dac volume control is reverse scale (lowest value is loudest)
-    // hence we reverse the calculated value
-    if (out == ES_MAIN) { vol_val = max_vol_val - vol_val; }
-
-    write_reg(ES8388_ADDR, lreg, vol_val);
-    write_reg(ES8388_ADDR, rreg, vol_val);
-}
-
-/**
- * @brief Test if device with I2C address for ES8388 is connected to the I2C bus 
- * 
- * @param sda which pin to use for I2C SDA
- * @param scl which pin to use for I2C SCL
- * @param frequency which frequency to use as I2C bus frequency
- * @return true device was found
- * @return false device was not found
- */
-bool ES8388::identify(int sda, int scl, uint32_t frequency)
-{
-    Wire.begin(sda, scl, frequency);
-    Wire.beginTransmission(ES8388_ADDR);
-    return Wire.endTransmission() == 0;
-}
 
 class AudioKit : public Device
 {
@@ -343,7 +80,7 @@ public:
 private:
     void InitI2SSpeakerOrMic(int mode);
     AC101 ac;
-    ES8388 es8388;
+    ES8388Control es8388;
 
     uint8_t out_vol;
 
@@ -364,7 +101,7 @@ void AudioKit::init()
 
     if ((is_es = es8388.begin(ES_IIC_DATA, ES_IIC_CLK)) == true)
     {
-        Serial.println("found ES8388");
+        Serial.println("found ES8388Control");
     }
     else
     {
@@ -481,7 +218,7 @@ void AudioKit::InitI2SSpeakerOrMic(int mode)
 
     if (is_es)
     {        
-        // ES8388 requires MCLK output.
+        // ES8388Control requires MCLK output.
         PIN_FUNC_SELECT(PERIPHS_IO_MUX_GPIO0_U, FUNC_GPIO0_CLK_OUT1);
         WRITE_PERI_REG(PIN_CTRL, 0xFFF0);
     }
@@ -506,7 +243,7 @@ void AudioKit::setWriteMode(int sampleRate, int bitDepth, int numChannels)
         {
             i2s_set_clk(SPEAKER_I2S_NUMBER, sampleRate, static_cast<i2s_bits_per_sample_t>(bitDepth), static_cast<i2s_channel_t>(numChannels));
         }
-        // ES8388 is never put into mono mode, hence we have to handle this case
+        // ES8388Control is never put into mono mode, hence we have to handle this case
         is_mono_stream_stereo_out = is_es && numChannels == 1;
     }
 }
@@ -561,7 +298,7 @@ bool AudioKit::readAudio(uint8_t *data, size_t size)
     }
     else
     {
-        // ES8388 returns stereo stream from Mic, but we need only one channel, 
+        // ES8388Control returns stereo stream from Mic, but we need only one channel, 
         // we drop channel 2 (right channel) here
         uint16_t data2[size];
         uint16_t *data1 = (uint16_t *)data;
@@ -582,7 +319,7 @@ void AudioKit::muteOutput(bool mute)
 {
     if (is_es)
     {
-        es8388.mute(ES8388::ES_MAIN, mute);
+        es8388.mute(ES8388Control::ES_MAIN, mute);
     }
     else
     {
@@ -601,7 +338,7 @@ void AudioKit::setVolume(uint16_t volume)
 
     if (is_es)
     {
-        es8388.volume(ES8388::ES_MAIN, out_vol);  
+        es8388.volume(ES8388Control::ES_MAIN, out_vol);  
     }
     else
     {
@@ -634,26 +371,25 @@ void AudioKit::ampOutput(int ampOut)
     switch (ampOut)
     {
     case AmpOut::AMP_OUT_SPEAKERS:
-        digitalWrite(GPIO_PA_EN, HIGH);
         mute[0] = false;
         mute[1] = true;
         break;
 
     case AmpOut::AMP_OUT_HEADPHONE:
-        digitalWrite(GPIO_PA_EN, LOW);
         mute[0] = true;
         mute[1] = false;
         break;
     }
 
     digitalWrite(GPIO_PA_EN, mute[0] ? LOW : HIGH);
+
     if (is_es)
     {
-        es8388.mute(ES8388::ES_OUT2, mute[1]);
-        es8388.volume(ES8388::ES_OUT2, mute[1] ? 0 : 100);
+        es8388.mute(ES8388Control::ES_OUT2, mute[1]);
+        es8388.volume(ES8388Control::ES_OUT2, mute[1] ? 0 : 100);
 
-        es8388.mute(ES8388::ES_OUT1, mute[0]);
-        es8388.volume(ES8388::ES_OUT1, mute[0] ? 0 : 100);
+        es8388.mute(ES8388Control::ES_OUT1, mute[0]);
+        es8388.volume(ES8388Control::ES_OUT1, mute[0] ? 0 : 100);
     }
     else
     {

--- a/PlatformIO/src/devices/ES8388Control.cpp
+++ b/PlatformIO/src/devices/ES8388Control.cpp
@@ -1,0 +1,252 @@
+#include <Arduino.h>
+#include "ES8388Control.h"
+#include <Wire.h>
+
+#define ES8388_ADDR 0x10
+
+/* ES8388 register */
+#define ES8388_CONTROL1 0x00
+#define ES8388_CONTROL2 0x01
+#define ES8388_CHIPPOWER 0x02
+#define ES8388_ADCPOWER 0x03
+#define ES8388_DACPOWER 0x04
+#define ES8388_CHIPLOPOW1 0x05
+#define ES8388_CHIPLOPOW2 0x06
+#define ES8388_ANAVOLMANAG 0x07
+#define ES8388_MASTERMODE 0x08
+
+/* ADC */
+#define ES8388_ADCCONTROL1 0x09
+#define ES8388_ADCCONTROL2 0x0a
+#define ES8388_ADCCONTROL3 0x0b
+#define ES8388_ADCCONTROL4 0x0c
+#define ES8388_ADCCONTROL5 0x0d
+#define ES8388_ADCCONTROL6 0x0e
+#define ES8388_ADCCONTROL7 0x0f
+#define ES8388_ADCCONTROL8 0x10
+#define ES8388_ADCCONTROL9 0x11
+#define ES8388_ADCCONTROL10 0x12
+#define ES8388_ADCCONTROL11 0x13
+#define ES8388_ADCCONTROL12 0x14
+#define ES8388_ADCCONTROL13 0x15
+#define ES8388_ADCCONTROL14 0x16
+
+/* DAC */
+#define ES8388_DACCONTROL1 0x17
+#define ES8388_DACCONTROL2 0x18
+#define ES8388_DACCONTROL3 0x19
+#define ES8388_DACCONTROL4 0x1a
+#define ES8388_DACCONTROL5 0x1b
+#define ES8388_DACCONTROL6 0x1c
+#define ES8388_DACCONTROL7 0x1d
+#define ES8388_DACCONTROL8 0x1e
+#define ES8388_DACCONTROL9 0x1f
+#define ES8388_DACCONTROL10 0x20
+#define ES8388_DACCONTROL11 0x21
+#define ES8388_DACCONTROL12 0x22
+#define ES8388_DACCONTROL13 0x23
+#define ES8388_DACCONTROL14 0x24
+#define ES8388_DACCONTROL15 0x25
+#define ES8388_DACCONTROL16 0x26
+#define ES8388_DACCONTROL17 0x27
+#define ES8388_DACCONTROL18 0x28
+#define ES8388_DACCONTROL19 0x29
+#define ES8388_DACCONTROL20 0x2a
+#define ES8388_DACCONTROL21 0x2b
+#define ES8388_DACCONTROL22 0x2c
+#define ES8388_DACCONTROL23 0x2d
+#define ES8388_DACCONTROL24 0x2e
+#define ES8388_DACCONTROL25 0x2f
+#define ES8388_DACCONTROL26 0x30
+#define ES8388_DACCONTROL27 0x31
+#define ES8388_DACCONTROL28 0x32
+#define ES8388_DACCONTROL29 0x33
+#define ES8388_DACCONTROL30 0x34
+
+bool ES8388Control::write_reg(uint8_t slave_add, uint8_t reg_add, uint8_t data)
+{
+    Wire.beginTransmission(slave_add);
+    Wire.write(reg_add);
+    Wire.write(data);
+    return Wire.endTransmission() == 0;
+}
+
+bool ES8388Control::read_reg(uint8_t slave_add, uint8_t reg_add, uint8_t &data)
+{
+    bool retval = false;
+    Wire.beginTransmission(slave_add);
+    Wire.write(reg_add);
+    Wire.endTransmission(false);
+    Wire.requestFrom((uint16_t)slave_add, (uint8_t)1, true);
+    if (Wire.available() >= 1)
+    {
+        data = Wire.read();
+        retval = true;
+    }
+    return retval;
+}
+
+bool ES8388Control::begin(int sda, int scl, uint32_t frequency)
+{
+    bool res = identify(sda, scl, frequency);
+
+    if (res == true)
+    {
+
+        /* mute DAC during setup, power up all systems, slave mode */
+        res &= write_reg(ES8388_ADDR, ES8388_DACCONTROL3, 0x04);
+        res &= write_reg(ES8388_ADDR, ES8388_CONTROL2, 0x50);
+        res &= write_reg(ES8388_ADDR, ES8388_CHIPPOWER, 0x00);
+        res &= write_reg(ES8388_ADDR, ES8388_MASTERMODE, 0x00);
+
+        /* power up DAC and enable LOUT1+2 / ROUT1+2, ADC sample rate = DAC sample rate */
+        res &= write_reg(ES8388_ADDR, ES8388_DACPOWER, 0x3e);
+        res &= write_reg(ES8388_ADDR, ES8388_CONTROL1, 0x12);
+
+        /* DAC I2S setup: 16 bit word length, I2S format; MCLK / Fs = 256*/
+        res &= write_reg(ES8388_ADDR, ES8388_DACCONTROL1, 0x18);
+        res &= write_reg(ES8388_ADDR, ES8388_DACCONTROL2, 0x02);
+
+        /* DAC to output route mixer configuration: ADC MIX TO OUTPUT */
+        res &= write_reg(ES8388_ADDR, ES8388_DACCONTROL16, 0x1B);
+        res &= write_reg(ES8388_ADDR, ES8388_DACCONTROL17, 0x90);
+        res &= write_reg(ES8388_ADDR, ES8388_DACCONTROL20, 0x90);
+
+        /* DAC and ADC use same LRCK, enable MCLK input; output resistance setup */
+        res &= write_reg(ES8388_ADDR, ES8388_DACCONTROL21, 0x80);
+        res &= write_reg(ES8388_ADDR, ES8388_DACCONTROL23, 0x00);
+
+        /* DAC volume control: 0dB (maximum, unattenuated)  */
+        res &= write_reg(ES8388_ADDR, ES8388_DACCONTROL5, 0x00);
+        res &= write_reg(ES8388_ADDR, ES8388_DACCONTROL4, 0x00);
+
+        /* power down ADC while configuring; volume: +9dB for both channels */
+        res &= write_reg(ES8388_ADDR, ES8388_ADCPOWER, 0xff);
+        res &= write_reg(ES8388_ADDR, ES8388_ADCCONTROL1, 0x88); // +24db
+
+        /* select LINPUT2 / RINPUT2 as ADC input; stereo; 16 bit word length, format right-justified, MCLK / Fs = 256 */
+        res &= write_reg(ES8388_ADDR, ES8388_ADCCONTROL2, 0xf0); // 50
+        res &= write_reg(ES8388_ADDR, ES8388_ADCCONTROL3, 0x80); // 00
+        res &= write_reg(ES8388_ADDR, ES8388_ADCCONTROL4, 0x0e);
+        res &= write_reg(ES8388_ADDR, ES8388_ADCCONTROL5, 0x02);
+
+        /* set ADC volume */
+        res &= write_reg(ES8388_ADDR, ES8388_ADCCONTROL8, 0x20);
+        res &= write_reg(ES8388_ADDR, ES8388_ADCCONTROL9, 0x20);
+
+        /* set LOUT1 / ROUT1 volume: 0dB (unattenuated) */
+        res &= write_reg(ES8388_ADDR, ES8388_DACCONTROL24, 0x1e);
+        res &= write_reg(ES8388_ADDR, ES8388_DACCONTROL25, 0x1e);
+
+        /* set LOUT2 / ROUT2 volume: 0dB (unattenuated) */
+        res &= write_reg(ES8388_ADDR, ES8388_DACCONTROL26, 0x1e);
+        res &= write_reg(ES8388_ADDR, ES8388_DACCONTROL27, 0x1e);
+
+        /* power up and enable DAC; power up ADC (no MIC bias) */
+        res &= write_reg(ES8388_ADDR, ES8388_DACPOWER, 0x3c);
+        res &= write_reg(ES8388_ADDR, ES8388_DACCONTROL3, 0x00);
+        res &= write_reg(ES8388_ADDR, ES8388_ADCPOWER, 0x00);
+    }
+
+    return res;
+}
+
+/**
+ * @brief (un)mute one of the two outputs or main dac output of the ES8388 by switching of the output register bits. Does not really mute the selected output, causes an attenuation. 
+ * hence should be used in conjunction with appropriate volume setting. Main dac output mute does mute both outputs
+ * 
+ * @param out 
+ * @param muted 
+ */
+void ES8388Control::mute(const ES8388_OUT out, const bool muted)
+{
+    uint8_t reg_addr;
+    uint8_t mask_mute;
+    uint8_t mask_val;
+
+    switch (out)
+    {
+    case ES_OUT1:
+        reg_addr = ES8388_DACPOWER;
+        mask_mute = (3 << 4);
+        mask_val = muted ? 0 : mask_mute;
+        break;
+    case ES_OUT2:
+        reg_addr = ES8388_DACPOWER;
+        mask_mute = (3 << 2);
+        mask_val = muted ? 0 : mask_mute;
+        break;
+    case ES_MAIN:
+    default:
+        reg_addr = ES8388_DACCONTROL3;
+        mask_mute = 1 << 2;
+        mask_val = muted ? mask_mute : 0;
+        break;
+    }
+
+    uint8_t reg;
+    if (read_reg(ES8388_ADDR, reg_addr, reg))
+    {
+        reg = (reg & ~mask_mute) | (mask_val & mask_mute);
+        write_reg(ES8388_ADDR, reg_addr, reg);
+    }
+}
+
+/**
+ * @brief Set volume gain for the main dac, or for one of the two output channels. Final gain = main gain + out channel gain 
+ * 
+ * @param out which gain setting to control
+ * @param vol 0-100 (100 is max)
+ */
+void ES8388Control::volume(const ES8388_OUT out, const uint8_t vol)
+{
+    const uint32_t max_vol = 100; // max input volume value
+
+    const int32_t max_vol_val = out == ES8388_OUT::ES_MAIN ? 96 : 0x21; // max register value for ES8388 out volume
+
+    uint8_t lreg = 0, rreg = 0;
+
+    switch (out)
+    {
+    case ES_MAIN:
+        lreg = ES8388_DACCONTROL4;
+        rreg = ES8388_DACCONTROL5;
+        break;
+    case ES_OUT1:
+        lreg = ES8388_DACCONTROL24;
+        rreg = ES8388_DACCONTROL25;
+        break;
+    case ES_OUT2:
+        lreg = ES8388_DACCONTROL26;
+        rreg = ES8388_DACCONTROL27;
+        break;
+    }
+
+    uint8_t vol_val = vol > max_vol ? max_vol_val : (max_vol_val * vol) / max_vol;
+
+    // main dac volume control is reverse scale (lowest value is loudest)
+    // hence we reverse the calculated value
+    if (out == ES_MAIN)
+    {
+        vol_val = max_vol_val - vol_val;
+    }
+
+    write_reg(ES8388_ADDR, lreg, vol_val);
+    write_reg(ES8388_ADDR, rreg, vol_val);
+}
+
+/**
+ * @brief Test if device with I2C address for ES8388 is connected to the I2C bus 
+ * 
+ * @param sda which pin to use for I2C SDA
+ * @param scl which pin to use for I2C SCL
+ * @param frequency which frequency to use as I2C bus frequency
+ * @return true device was found
+ * @return false device was not found
+ */
+bool ES8388Control::identify(int sda, int scl, uint32_t frequency)
+{
+    Wire.begin(sda, scl, frequency);
+    Wire.beginTransmission(ES8388_ADDR);
+    return Wire.endTransmission() == 0;
+}

--- a/PlatformIO/src/devices/ES8388Control.h
+++ b/PlatformIO/src/devices/ES8388Control.h
@@ -1,0 +1,23 @@
+#pragma once
+#include <stdint.h>
+
+class ES8388Control
+{
+
+    bool write_reg(uint8_t slave_add, uint8_t reg_add, uint8_t data);
+    bool read_reg(uint8_t slave_add, uint8_t reg_add, uint8_t &data);
+    bool identify(int sda, int scl, uint32_t frequency);
+
+public:
+    bool begin(int sda = -1, int scl = -1, uint32_t frequency = 400000U);
+
+    enum ES8388_OUT
+    {
+        ES_MAIN, // this is the DAC output volume (both outputs)
+        ES_OUT1, // this is the additional gain for OUT1
+        ES_OUT2  // this is the additional gain for OUT2
+    };
+
+    void mute(const ES8388_OUT out, const bool muted);
+    void volume(const ES8388_OUT out, const uint8_t vol);
+};

--- a/PlatformIO/src/devices/Inmp441.hpp
+++ b/PlatformIO/src/devices/Inmp441.hpp
@@ -33,7 +33,7 @@ class Inmp441 : public Device
     void init();
     void updateColors(int colors);
     bool readAudio(uint8_t *data, size_t size);
-
+    int numAmpOutConfigurations() { return 1; };
   private:
     char* i2s_read_buff = (char*) calloc(I2S_READ_LEN, sizeof(char));
 };

--- a/PlatformIO/src/devices/Inmp441Max98357a.hpp
+++ b/PlatformIO/src/devices/Inmp441Max98357a.hpp
@@ -43,6 +43,9 @@ class Inmp441Max98357a : public Device
     void setWriteMode(int sampleRate, int bitDepth, int numChannels);
     void writeAudio(uint8_t *data, size_t size, size_t *bytes_written);
     IndicatorLight *indicator_light = new IndicatorLight(LED_FLASH);
+
+    int numAmpOutConfigurations() { return 1; };
+    
   private:
     char* i2s_read_buff = (char*) calloc(I2S_READ_LEN, sizeof(char));
 };

--- a/PlatformIO/src/devices/M5AtomEcho.hpp
+++ b/PlatformIO/src/devices/M5AtomEcho.hpp
@@ -24,6 +24,8 @@ public:
   void writeAudio(uint8_t *data, size_t size, size_t *bytes_written);
   bool readAudio(uint8_t *data, size_t size);
   bool isHotwordDetected();
+  int numAmpOutConfigurations() { return 1; };
+
 private:
   void InitI2SSpeakerOrMic(int mode);
 };

--- a/PlatformIO/src/index_html.h
+++ b/PlatformIO/src/index_html.h
@@ -78,6 +78,7 @@ input::-moz-focus-inner,input::-moz-focus-outer {border: 0;}
       <select name="amp_output">
         <option value="0" %AMP_OUT_SPEAKERS%>Speakers</option>
         <option value="1" %AMP_OUT_HEADPHONE%>Headphone</option>
+        <option value="2" %AMP_OUT_BOTH%>Headphone+Speakers</option>
       </select>
     </div>
     <div class="input-container">


### PR DESCRIPTION
@Romkabouter :
Please have a look at the changes and see if you like them. None of these are essential changes like the audio improvement, nevertheless they may help:
Improved the ES8388 code, factored it out into a separate set of files to get AudioKit.hpp cleaner and more focused again.
The audio output switching now works on the Audiokit, it should do this for both HW variants (AC101 and ES8388), although I could only test ES8388 side. @sehraf : Maybe you can have a look at this. 

Part of this was to make the webserver reflecting the actual hardware capabilities (one  output choice -> (just speaker -> INMP441 + MAX, M5 Atom), two (speaker, headphone -> Matrixvoice), three (Speaker, HP, Speaker+HP -> Audiokit). Turned out to involve a bit more change than originally anticipated.

 