### PR TITLE
Fix for AC101 AudioKit mute output issue

### DIFF
--- a/PlatformIO/src/devices/AudioKit.hpp
+++ b/PlatformIO/src/devices/AudioKit.hpp
@@ -423,7 +423,7 @@ void AudioKit::ampOutput(int ampOut)
     else
     {
         const uint8_t vol = (out_vol * 63)/100;
-        ac.SetVolumeSpeaker(mute[0]?vol:0);
-        ac.SetVolumeSpeaker(mute[1]?vol:0);
+        ac.SetVolumeSpeaker(mute[0]? 0 : vol);
+        ac.SetVolumeHeadphone(mute[1]? 0 : vol);
     }
 }


### PR DESCRIPTION
The audio output selection code was not handling the AC101 case correctly. It never muted the headphone output and instead of disabling it muted the speaker when AMP_OUT_SPEAKER or AMP_OUT_BOTH were called. Fixed now and verified to work as intended with an AC101 Audiokit.