### PR TITLE
Web param handling improvements, A1S new pinout support, minor changes

### DIFF
--- a/PlatformIO/src/General.hpp
+++ b/PlatformIO/src/General.hpp
@@ -71,9 +71,9 @@ bool mqttConnected = false;
 bool DEBUG = false;
 bool configChanged = false;
 
-std::string audioFrameTopic = std::string("hermes/audioServer/") + config.siteid + std::string("/audioFrame");
-std::string playBytesTopic = std::string("hermes/audioServer/") + config.siteid + std::string("/playBytes/#");
-std::string playFinishedTopic = std::string("hermes/audioServer/") + config.siteid + std::string("/playFinished");
+std::string audioFrameTopic("hermes/audioServer/" + config.siteid + "/audioFrame");
+std::string playBytesTopic = "hermes/audioServer/" + config.siteid + "/playBytes/#";
+std::string playFinishedTopic = "hermes/audioServer/" + config.siteid + "/playFinished";
 std::string hotwordTopic = "hermes/hotword/#";
 std::string audioTopic = config.siteid + std::string("/audio");
 std::string ledTopic = config.siteid + std::string("/led");
@@ -91,7 +91,7 @@ int queueDelay = 10;
 int sampleRate = 16000;
 int numChannels = 2;
 int bitDepth = 16;
-int current_colors = COLORS_IDLE;
+StateColors current_colors = COLORS_IDLE;
 static EventGroupHandle_t audioGroup;
 SemaphoreHandle_t wbSemaphore;
 TaskHandle_t i2sHandle;
@@ -176,37 +176,23 @@ XT_Wav_Class::XT_Wav_Class(const unsigned char *WavData) {
     }
 }
 
+void updateMqttTopicsStrings()
+{
+    audioFrameTopic = std::string("hermes/audioServer/") + config.siteid + std::string("/audioFrame");
+    playBytesTopic = std::string("hermes/audioServer/") + config.siteid + std::string("/playBytes/#");
+    playFinishedTopic = std::string("hermes/audioServer/") + config.siteid + std::string("/playFinished");
+    audioTopic = config.siteid + std::string("/audio");
+    ledTopic = config.siteid + std::string("/led");
+    debugTopic = config.siteid + std::string("/debug");
+    restartTopic = config.siteid + std::string("/restart");
 
-// to add more variables use a C++ lambda, it must either directly return a String, or specify return type ("-> String"), or both 
-const std::map<const std::string, String (*)()> processor_values = {
-    {"MQTT_HOST",           []() -> String { return config.mqtt_host.c_str();} },
-    {"MQTT_PORT",           []() { return String(config.mqtt_port);} },
-    {"MQTT_USER",           []() -> String { return config.mqtt_user.c_str(); } },
-    {"MQTT_PASS",           []() -> String { return config.mqtt_pass.c_str(); } },
-    {"MUTE_INPUT",          []() -> String { return (config.mute_input) ? "checked" : ""; } },
-    {"MUTE_OUTPUT",         []() -> String { return(config.mute_output) ? "checked" : ""; } },
-    {"AMP_OUT_SPEAKERS",    []() -> String { return device->numAmpOutConfigurations() < 1? "hidden" : (config.amp_output == AMP_OUT_SPEAKERS) ? "selected" : ""; } },
-    {"AMP_OUT_HEADPHONE",   []() -> String { return device->numAmpOutConfigurations() < 2? "hidden" : (config.amp_output == AMP_OUT_HEADPHONE) ? "selected" : ""; } },
-    {"AMP_OUT_BOTH",        []() -> String { return device->numAmpOutConfigurations() < 3? "hidden" : (config.amp_output == AMP_OUT_BOTH) ? "selected" : ""; } },
-    {"BRIGHTNESS",          []() { return String(config.brightness); } },
-    {"HW_BRIGHTNESS",       []() { return String(config.hotword_brightness); } },
-    {"HW_LOCAL",            []() -> String { return (config.hotword_detection == HW_LOCAL) ? "selected" : ""; } },
-    {"HW_REMOTE",           []() -> String { return (config.hotword_detection == HW_REMOTE) ? "selected" : ""; } },
-    {"VOLUME",              []() { return String(config.volume); } },
-    {"GAIN",                []() { return String(config.gain); } },
-    {"SITEID",              []() -> String { return config.siteid.c_str(); } },
-    {"ANIMATIONSUPPORT",    []() -> String { return device->animationSupported() ? "block" : "none"; } },
-    {"ANIM_SOLID",          []() -> String { return (config.animation == SOLID) ? "selected" : ""; } },
-    {"ANIM_RUNNING",        []() -> String { return device->runningSupported() ? (config.animation == RUN) ? "selected" : "" : "hidden"; } },
-    {"ANIM_PULSING",        []() -> String { return device->pulsingSupported() ? (config.animation == PULSE) ? "selected" : "" : "hidden"; } },
-    {"ANIM_BLINKING",       []() -> String { return device->blinkingSupported() ? (config.animation == BLINK) ? "selected" : "" : "hidden"; } },
-};
-
-// this function supplies template variables to the template engine
-String processor(const String& var){
-    auto item = processor_values.find(var.c_str());
-    return item != processor_values.end() ? item->second() : String();
 }
+
+
+//template<typename T> String toStringFunc(T val) { return String(val);}
+template<typename T> String toStringFunc(T& val) { return String(val);}
+template<> String toStringFunc(std::string& val) { return val.c_str();}
+String toStringFunc(const char* val) { return String(val);}
 
 // if there is not specialization for the given result type, we assume the html parameter is a integer number and can
 // be casted to the target type
@@ -218,68 +204,229 @@ template <> bool processParamConvert(AsyncWebParameter *p) { return p->value().e
 // for strings we return a string object
 template <> std::string processParamConvert(AsyncWebParameter *p) { return p->value().c_str();}
 
-template <typename T> bool processParam(AsyncWebParameter *p, const char* p_name, T& p_val)
+template <typename T> bool processParam(AsyncWebParameter *p, T& p_val)
 {
     bool retval = false;
-    if (p->name() == p_name)
+    T new_p_val = processParamConvert<T>(p);
+    if (p_val != new_p_val)
     {
-        T new_p_val = processParamConvert<T>(p);
-        if (p_val != new_p_val)
-        {
-            Serial.printf("%s changed\n",p_name);
-            p_val = new_p_val;
-            retval = true;
-        }
+        p_val = new_p_val;
+        retval = true;
     }
     return retval;
+}
+
+// these two gloval variables are used to simplify
+// handling of "communication" out of the config parameter processing
+// there more elegant solutions possible
+static bool reconnectNeeded = false;
+static bool doReconnect = false;
+
+struct Conv 
+{
+    /**
+     * @brief the function used to turn the parameter into its string representation
+     * this is then used to replace all occurrences of %LABEL_IN_CAPS% in the index.html.h 
+     * 
+     */ 
+    String (*toWebString)();
+
+    /**
+     * @brief the pointer to the function to  save the website parameter into the config data.
+     * if not relevant, just return false as lambda function will do or leave default.
+     *  no op template: [](AsyncWebParameter *p) { return false; } 
+     *  otherwise [](AsyncWebParameter *p) { return processParam(p, config.NAME_OF_FIELD); }
+     * 
+     * @param p the parameter to process from the web server request 
+     * @returns true if value was changed, false otherwise
+     */
+    bool   (*toValue)(AsyncWebParameter* p) ;
+
+    /**
+     * @brief the pointer to function to be called if the parameter was changed during configuration, used to apply the value
+     * specify empty lambda function if not directly applicable: []() {}
+     */
+    void   (*apply)();
+};
+
+const std::map<const std::string, Conv> config_values = {
+    { "siteid", { 
+            []() { return toStringFunc(config.siteid); },
+            [](AsyncWebParameter *p) { return processParam(p, config.siteid); },
+            []() { reconnectNeeded = true; updateMqttTopicsStrings(); } 
+        }
+    },
+    { "mqtt_host", { 
+            []() { return toStringFunc(config.mqtt_host); },
+            [](AsyncWebParameter *p) { return processParam(p, config.mqtt_host); },
+            []() { reconnectNeeded = true; } 
+        }
+    },
+    { "mqtt_port", { 
+            []() { return toStringFunc(config.mqtt_port); },
+            [](AsyncWebParameter *p) { return processParam(p, config.mqtt_port); },
+            []() { reconnectNeeded = true; } 
+        }
+    },
+    { "mqtt_user", { 
+            []() { return toStringFunc(config.mqtt_user); },
+            [](AsyncWebParameter *p) { return processParam(p, config.mqtt_user); },
+            []() { reconnectNeeded = true; } 
+        }
+    },
+    { "mqtt_pass", { 
+            []() { return toStringFunc(config.mqtt_pass); },
+            [](AsyncWebParameter *p) { return processParam(p, config.mqtt_pass); },
+            []() { reconnectNeeded = true; } 
+        }
+    },
+    { "volume", { 
+            []() { return toStringFunc(config.volume); },
+            [](AsyncWebParameter *p) { return processParam(p, config.volume); },
+            []() { device->setVolume(config.volume); } 
+        }
+    },
+    { "gain", { 
+            []() { return toStringFunc(config.gain); },
+            [](AsyncWebParameter *p) { return processParam(p, config.gain); },
+            []() { device->setGain(config.gain); } 
+        }
+    },
+    { "brightness", { 
+            []() { return toStringFunc(config.brightness); },
+            [](AsyncWebParameter *p) { return processParam(p, config.brightness); },
+            []() { device->updateBrightness(config.brightness); } 
+        }
+    },
+    { "hw_brightness", { 
+            []() { return toStringFunc(config.hotword_brightness); },
+            [](AsyncWebParameter *p) { return processParam(p, config.hotword_brightness); },
+            []() {} 
+        }
+    },
+    { "mute_input", { 
+            []() { return toStringFunc((config.mute_input) ? "checked" : ""); },
+            [](AsyncWebParameter *p) { return processParam(p, config.mute_input); },
+            []() {} 
+        }
+    },
+    { "mute_output", { 
+            []() { return toStringFunc((config.mute_output) ? "checked" : ""); },
+            [](AsyncWebParameter *p) { return processParam(p, config.mute_output); },
+            []() {} 
+        }
+    },
+    { "amp_output", { 
+            []() { return toStringFunc(config.amp_output); },
+            [](AsyncWebParameter *p) { return processParam(p, config.amp_output); },
+            []() { device->ampOutput(config.amp_output); } 
+        }
+    },
+    { "hotword_detection", { 
+            []() { return toStringFunc(config.hotword_detection); },
+            [](AsyncWebParameter *p) { return processParam(p,config.hotword_detection); },
+            []() {} 
+        }
+    },
+    { "hw_local", { 
+            []() { return toStringFunc((config.hotword_detection == HW_LOCAL) ? "selected" : ""); },
+            [](AsyncWebParameter *p) { return false; },
+            []() {} 
+        }
+    },
+    { "hw_remote", { 
+            []() { return toStringFunc((config.hotword_detection == HW_REMOTE) ? "selected" : ""); },
+            [](AsyncWebParameter *p) { return false; },
+            []() {} 
+        }
+    },
+    { "amp_out_speakers", { 
+            []() { return toStringFunc(device->numAmpOutConfigurations() < 1? "hidden" : (config.amp_output == AMP_OUT_SPEAKERS) ? "selected" : ""); },
+            [](AsyncWebParameter *p) { return false; },
+            []() {} 
+        }
+    },
+    { "amp_out_headphone", { 
+            []() { return toStringFunc(device->numAmpOutConfigurations() < 2? "hidden" : (config.amp_output == AMP_OUT_HEADPHONE) ? "selected" : ""); },
+            [](AsyncWebParameter *p) { return false; },
+            []() {} 
+        }
+    },
+    { "amp_out_both", { 
+            []() { return toStringFunc(device->numAmpOutConfigurations() < 3? "hidden" : (config.amp_output == AMP_OUT_BOTH) ? "selected" : ""); },
+            [](AsyncWebParameter *p) { return false; },
+            []() {} 
+        }
+    },
+    {"animationsupported",  {   
+            []() -> String { return device->animationSupported() ? "block" : "none"; },
+            [](AsyncWebParameter *p) { return false; },
+            []() {} 
+        }
+    },
+    { "animation", { 
+            []() { return toStringFunc(config.animation); },
+            [](AsyncWebParameter *p) { return processParam(p, config.animation); },
+            []() {} 
+        }
+    },
+    {"anim_solid", {
+            []() -> String { return (config.animation == SOLID) ? "selected" : ""; },
+            [](AsyncWebParameter *p) { return false; },
+            []() {}  
+        }
+    },
+    {"anim_running", {
+            []() -> String { return device->runningSupported() ? (config.animation == RUN) ? "selected" : "" : "hidden"; },
+            [](AsyncWebParameter *p) { return false; },
+            []() {} 
+        } 
+    },
+    {"anim_pulsing", {
+            []() -> String { return device->pulsingSupported() ? (config.animation == PULSE) ? "selected" : "" : "hidden"; },
+            [](AsyncWebParameter *p) { return false; },
+            []() {} 
+        } 
+    },
+    {"anim_blinking", {      
+            []() -> String { return device->blinkingSupported() ? (config.animation == BLINK) ? "selected" : "" : "hidden"; },
+            [](AsyncWebParameter *p) { return false; },
+            []() {} 
+        }
+    },
+};
+
+// this function supplies template variables to the template engine
+String processor2(const String& _var){
+    std::string var(_var.c_str());
+    std::for_each(var.begin(), var.end(), [](char & c) {
+        c = ::tolower(c);
+    });
+
+    auto item = config_values.find(var.c_str());
+    return item != config_values.end() ? item->second.toWebString() : String();
 }
 
 void handleFSf ( AsyncWebServerRequest* request, const String& route ) {
     AsyncWebServerResponse *response ;
     bool saveNeeded = false;
-    bool rebootNeeded = false;
 
     if ( route.indexOf ( "index.html" ) >= 0 ) // Index page is in PROGMEM
     {
         if (request->method() == HTTP_POST) {
-            int params = request->params();
-            bool mi_found = false;
-            bool mo_found = false;
-            for(int i=0;i<params;i++){
-                AsyncWebParameter* p = request->getParam(i);
-                Serial.printf("Parameter %s, value %s\r\n", p->name().c_str(), p->value().c_str());
-
-                rebootNeeded |= processParam(p, "siteid", config.siteid);
-                rebootNeeded |= processParam(p, "mqtt_host", config.mqtt_host);
-                rebootNeeded |= processParam(p, "mqtt_pass", config.mqtt_pass);
-                rebootNeeded |= processParam(p, "mqtt_user", config.mqtt_user);
-                rebootNeeded |= processParam(p, "mqtt_port", config.mqtt_port);
-                saveNeeded |= processParam(p, "mute_input", config.mute_input);
-                saveNeeded |= processParam(p, "mute_output", config.mute_output);
-                saveNeeded |= processParam(p, "amp_output", config.amp_output);
-                saveNeeded |= processParam(p, "brightness", config.brightness);
-                saveNeeded |= processParam(p, "hw_brightness", config.hotword_brightness);
-                saveNeeded |= processParam(p, "hotword_detection", config.hotword_detection);
-                saveNeeded |= processParam(p, "animation", config.animation);
-                saveNeeded |= processParam(p, "gain", config.gain);
-                saveNeeded |= processParam(p, "volume", config.volume);
-
-                mi_found |= (p->name() == "mute_input");
-                mo_found |= (p->name() == "mute_output");
-
+            for(auto config_value: config_values)
+            {
+                AsyncWebParameter* p = request->getParam(config_value.first.c_str(), true);
+                if (p)
+                {
+                  bool sn = config_value.second.toValue(p);
+                  Serial.printf("Parameter %s, value %s save? = %d\r\n", p->name().c_str(), p->value().c_str(), sn);
+                  if (sn) { config_value.second.apply(); }
+                  saveNeeded |= sn;
+                }
             }
 
-            if (!mi_found && config.mute_input) {
-                Serial.println("Mute input not found, value = off");
-                config.mute_input = false;
-                saveNeeded = true;
-            }
-            if (!mo_found && config.mute_output) {
-                Serial.println("Mute output not found, value = off");
-                config.mute_output = false;
-                saveNeeded = true;
-            }
-            if (saveNeeded || rebootNeeded) {
+            if (saveNeeded || reconnectNeeded) {
                 Serial.println("Settings changed, saving configuration");
                 saveConfiguration(configfile, config);
                 configChanged = true;
@@ -287,21 +434,24 @@ void handleFSf ( AsyncWebServerRequest* request, const String& route ) {
                 Serial.println("No settings changed");
             }
         }
-        if (rebootNeeded) {
-            response = request->beginResponse_P ( 200, "text/html", "<html><head><title>Rebooting...</title><script>setTimeout(function(){window.location.href = '/';},4000);</script></head><body><h1>Configuration saved, rebooting!</h1></body></html>");
+        if (reconnectNeeded) {
+            response = request->beginResponse_P ( 200, "text/html", "<html><head><title>Reconnecting...</title><script>setTimeout(function(){window.location.href = '/';},4000);</script></head><body><h1>Configuration saved, reconnecting using changed settings!</h1></body></html>");
         } else {
-            response = request->beginResponse_P ( 200, "text/html", index_html, processor );
+            response = request->beginResponse_P ( 200, "text/html", index_html, processor2 );
         }
 
     } else {
         response = request->beginResponse_P ( 200, "text/html", "<html><body>unkown route</body></html>") ;
     }
-
+    
     request->send ( response ) ;
     
-    if (rebootNeeded) {
-        Serial.println("Rebooting!");
-        ESP.restart();    
+    if (reconnectNeeded) {
+        Serial.println("Reconnecting!");
+        delay(1000);
+        reconnectNeeded = false;
+        doReconnect = true;
+        // ESP.restart();    
     }
 
 }
@@ -341,8 +491,7 @@ void loadConfiguration(const char *filename, Config &config) {
   // Deserialize the JSON document
   DeserializationError error = deserializeJson(doc, file);
   if (error) {
-    Serial.println(F("Failed to read file, using default configuration"));
-    config.mqtt_host = MQTT_HOST;
+    Serial.println(F("Failed to read file, using default configuration"));    
   } else {
     serializeJsonPretty(doc, Serial);
     Serial.println();  
@@ -354,24 +503,23 @@ void loadConfiguration(const char *filename, Config &config) {
     config.mute_input = doc.getMember("mute_input").as<int>();
     config.mute_output = doc.getMember("mute_output").as<int>();
     config.amp_output = doc.getMember("amp_output").as<int>();
-    device->ampOutput(config.amp_output);
     config.brightness = doc.getMember("brightness").as<int>();
-    device->updateBrightness(config.brightness);
     config.hotword_brightness = doc.getMember("hotword_brightness").as<int>();
     //config.hotword_detection = doc.getMember("hotword_detection").as<int>();
     config.hotword_detection = 1;
     config.volume = doc.getMember("volume").as<int>();
-    device->setVolume(config.volume);
     config.gain = doc.getMember("gain").as<int>();
     config.animation = doc.getMember("animation").as<int>();
+
+    // apply configuration values
+    device->ampOutput(config.amp_output);
+    device->updateBrightness(config.brightness);
+    device->setVolume(config.volume);
     device->setGain(config.gain);
-    audioFrameTopic = std::string("hermes/audioServer/") + config.siteid + std::string("/audioFrame");
-    playBytesTopic = std::string("hermes/audioServer/") + config.siteid + std::string("/playBytes/#");
-    playFinishedTopic = std::string("hermes/audioServer/") + config.siteid + std::string("/playFinished");
-    audioTopic = config.siteid + std::string("/audio");
-    ledTopic = config.siteid + std::string("/led");
-    debugTopic = config.siteid + std::string("/debug");
-    restartTopic = config.siteid + std::string("/restart");
+    
+    // reconfigure if siteid changes
+    updateMqttTopicsStrings();
+
   }
   file.close();
 }

--- a/PlatformIO/src/Satellite.cpp
+++ b/PlatformIO/src/Satellite.cpp
@@ -230,5 +230,13 @@ void loop() {
   if (WiFi.isConnected()) {
     ArduinoOTA.handle();
   }
+
+  // unless we are not connected, reconnect now using new settings
+  if (doReconnect && fsm::is_in_state<MQTTDisconnected>() == false && fsm::is_in_state<WifiDisconnected>() == false ) 
+  {
+    send_event(MQTTDisconnectedEvent());
+  }
+  doReconnect = false;
+  
   fsm::run();
 }

--- a/PlatformIO/src/device.h
+++ b/PlatformIO/src/device.h
@@ -9,7 +9,8 @@ int wifi_disc_colors[4] = {255, 0, 0, 0};
 int ota_colors[4] = {0, 0, 0, 255};
 int tts_colors[4] = {173, 17, 240, 0};
 int error_colors[4] = {150, 255, 0, 0};
-enum {
+
+enum StateColors {
   COLORS_HOTWORD = 0,
   COLORS_WIFI_CONNECTED = 1,
   COLORS_WIFI_DISCONNECTED = 2,
@@ -19,7 +20,7 @@ enum {
   COLORS_ERROR = 6
 };
 
-std::map<int, int*> ColorMap = {
+std::map<StateColors, int*> ColorMap = {
     {COLORS_IDLE, idle_colors },
     {COLORS_HOTWORD, hotword_colors },
     {COLORS_WIFI_CONNECTED, wifi_conn_colors },
@@ -58,12 +59,12 @@ class Device {
      //You can init your device here if needed
     virtual void init() {};
      //If your device has leds, override these methods to set the colors and brightness
-    virtual void updateColors(int colors) {};
+    virtual void updateColors(StateColors colors) {};
     //You can create some animation here
-    virtual void animate(int colors, int mode) {};
-    virtual void animateRunning(int colors) {};
-    virtual void animatePulsing(int colors) {};
-    virtual void animateBlinking(int colors) {};
+    virtual void animate(StateColors colors, int mode) {};
+    virtual void animateRunning(StateColors colors) {};
+    virtual void animatePulsing(StateColors colors) {};
+    virtual void animateBlinking(StateColors colors) {};
     //
     virtual void updateBrightness(int brightness) {};
     //It may be needed to switch between read and write, i.e. if the need the same PIN

--- a/PlatformIO/src/device.h
+++ b/PlatformIO/src/device.h
@@ -11,13 +11,13 @@ int tts_colors[4] = {173, 17, 240, 0};
 int error_colors[4] = {150, 255, 0, 0};
 
 enum StateColors {
-  COLORS_HOTWORD = 0,
-  COLORS_WIFI_CONNECTED = 1,
-  COLORS_WIFI_DISCONNECTED = 2,
-  COLORS_IDLE = 3,
-  COLORS_OTA = 4,
-  COLORS_TTS = 5,
-  COLORS_ERROR = 6
+  COLORS_HOTWORD = 0, // Listening to user input after hotword being detected
+  COLORS_WIFI_CONNECTED = 1, // Wifi is connected. Note, this does not indicate successfull connection to MQTT
+  COLORS_WIFI_DISCONNECTED = 2, // Wifi is not connected
+  COLORS_IDLE = 3, // idle, i.e. Wifi and MQTT connected, device is listening/waiting for activation by hotword and/or key press
+  COLORS_OTA = 4, // over the air update in progress
+  COLORS_TTS = 5, // device is outputting a speech "message" from the TTS
+  COLORS_ERROR = 6 // device has been put in an error state, this is controlled via MQTT error topic
 };
 
 std::map<StateColors, int*> ColorMap = {
@@ -65,8 +65,14 @@ class Device {
     virtual void animateRunning(StateColors colors) {};
     virtual void animatePulsing(StateColors colors) {};
     virtual void animateBlinking(StateColors colors) {};
-    //
+    
+    /**
+     * @brief Set the brightness of the light effects in percent, some devices may not support this
+     * 
+     * @param brightness  value in range from 0 to 100 
+     */
     virtual void updateBrightness(int brightness) {};
+
     //It may be needed to switch between read and write, i.e. if the need the same PIN
     //Override both methods
     virtual void setReadMode() {}; 

--- a/PlatformIO/src/devices/AudioKit.hpp
+++ b/PlatformIO/src/devices/AudioKit.hpp
@@ -264,8 +264,6 @@ void AudioKit::InitI2SSpeakerOrMic(int mode)
 
     err += i2s_driver_install(SPEAKER_I2S_NUMBER, &i2s_config, 0, NULL);
 
-    const i2s_pin_config_t* tx_pin_config_p;
-
     err += i2s_set_pin(SPEAKER_I2S_NUMBER, &(a1s_pinouts[variant].i2s));
 
     if (is_es)

--- a/PlatformIO/src/devices/AudioKit.hpp
+++ b/PlatformIO/src/devices/AudioKit.hpp
@@ -8,23 +8,74 @@
 #include <IndicatorLight.h>
 #include "ES8388Control.h"
 
-// I2S pins
-#define CONFIG_I2S_BCK_PIN 27
-#define CONFIG_I2S_LRCK_PIN 26
-#define CONFIG_I2S_DATA_PIN 25
-#define CONFIG_I2S_DATA_IN_PIN 35
+// there are multiple versions of the new ESP32-A1S in the wild
+// with different pinouts for I2S and I2C
+// see https://github.com/Ai-Thinker-Open/ESP32-A1S-AudioKit/issues/26
+//
+// This is the newer version which brings back usable keys 4 to 6: https://github.com/Ai-Thinker-Open/ESP32-A1S-AudioKit/files/7387472/esp32-a1s_v2.3-20210508.1.pdf
 
-#define ES_CONFIG_I2S_BCK_PIN 5
-#define ES_CONFIG_I2S_LRCK_PIN 25
-#define ES_CONFIG_I2S_DATA_PIN 26
-#define ES_CONFIG_I2S_DATA_IN_PIN 35
+enum A1SVariant
+{
+    ES8388_V1 = 0,
+    ES8388_V2,
+    AC101_V1,
+    UNIDENTIFIED
+};
 
-// AC101 I2C pins
-#define IIC_CLK 32
-#define IIC_DATA 33
+struct i2c_pin_config_t
+{
+    int sda;
+    int scl;
+};
 
-#define ES_IIC_CLK 23
-#define ES_IIC_DATA 18
+struct A1S_Pinouts
+{
+    const char* label;
+    A1SVariant variant;
+    i2s_pin_config_t i2s;
+    i2c_pin_config_t i2c;
+};
+
+const A1S_Pinouts a1s_pinouts[] = {
+    // ESP32-A1S initial pinout ES8388
+    {
+        .label = "ES8388 Pinout Variant 1",
+        .variant = A1SVariant::ES8388_V1,
+        .i2s =
+            {
+                .bck_io_num = 5,
+                .ws_io_num = 25,
+                .data_out_num = 26,
+                .data_in_num = 35,
+            },
+            .i2c = { .sda = 18, .scl = 23 }
+    },
+    // ESP32-A1S second pinout ES8388
+    {
+        .label = "ES8388 Pinout Variant 2",
+        .variant = A1SVariant::ES8388_V2,
+        .i2s = {
+            .bck_io_num = 27,
+            .ws_io_num = 25,
+            .data_out_num = 26,
+            .data_in_num = 35,
+        },
+        .i2c = { .sda = 33, .scl = 32 }
+    },
+    // ESP32-A1S AC101 varian
+    {
+        .label = "AC101",
+        .variant = A1SVariant::AC101_V1,
+        .i2s = {
+            .bck_io_num = 27,
+            .ws_io_num = 26,
+            .data_out_num = 25,
+            .data_in_num = 35,
+        },
+        .i2c = { .sda = 33, .scl = 32 }
+    },
+};
+
 
 // amplifier enable pin
 #define GPIO_PA_EN GPIO_NUM_21
@@ -41,9 +92,9 @@
 #define KEY1_GPIO GPIO_NUM_36
 #define KEY2_GPIO GPIO_NUM_13 // may be in use for other purposes, see onboard config switch
 #define KEY3_GPIO GPIO_NUM_19 // also activates LED D4 if pressed
-#define KEY4_GPIO GPIO_NUM_23 // do not use on A1S V2.3 -> I2C ES8388
-#define KEY5_GPIO GPIO_NUM_18 // do not use on A1S V2.3 -> I2C ES8388
-#define KEY6_GPIO GPIO_NUM_5  // do not use on A1S V2.3 -> I2S
+#define KEY4_GPIO GPIO_NUM_23 // do not use on A1S V2.3 with initial pinout -> I2C ES8388
+#define KEY5_GPIO GPIO_NUM_18 // do not use on A1S V2.3 with initial pinout -> I2C ES8388
+#define KEY6_GPIO GPIO_NUM_5  // do not use on A1S V2.3 with initial pinout -> I2S
 
 // alias
 #define KEY_LISTEN KEY3_GPIO
@@ -84,9 +135,11 @@ private:
     AC101 ac;
     ES8388Control es8388;
 
+
     uint8_t out_vol;
     AmpOut out_amp = AMP_OUT_SPEAKERS;
 
+    A1SVariant variant = UNIDENTIFIED;
     bool is_es = false;
     bool is_mono_stream_stereo_out = false;
     uint16_t key_listen;
@@ -98,27 +151,40 @@ AudioKit::AudioKit(){};
 
 void AudioKit::init()
 {
-    Serial.print("Connect to Codec... ");
+    Serial.print("Identifying Codec... ");
 
-    if ((is_es = es8388.begin(ES_IIC_DATA, ES_IIC_CLK)) == true)
+    for (auto pinout: a1s_pinouts)
     {
-        Serial.println("found ES8388Control");
-    }
-    else
-    {
-        Serial.println("looking for AC101...");
-        while (!ac.begin(IIC_DATA, IIC_CLK))
+        Serial.printf("Checking for %s...\r\n", pinout.label);
+        if (pinout.variant != AC101_V1)
         {
-            Serial.printf("failed!\n");
-            delay(1000);
+
+            if ((is_es = es8388.begin(pinout.i2c.sda, pinout.i2c.scl)) == true)
+            {
+            variant = pinout.variant;
+            }
+        } else {
+            if (ac.begin(pinout.i2c.sda, pinout.i2c.scl))
+            {
+                variant = pinout.variant;
+                ac.SetMode(AC101::MODE_ADC_DAC);
+            }
         }
-        ac.SetMode(AC101::MODE_ADC_DAC);
+        // we are done here now
+        if (variant != UNIDENTIFIED) { break; }
+    }
+    if (variant!= UNIDENTIFIED)
+    {
+    Serial.printf("Found audio controller %s at SDA: %d / SCL: %d\n", a1s_pinouts[variant].label, a1s_pinouts[variant].i2c.sda, a1s_pinouts[variant].i2c.scl);
+    } else
+    {
+        Serial.println("No supported controller found, stopping operation!");
+        while (true); // TODO: Better handling for no controller found 
     }
 
     key_listen = is_es? ES_KEY_LISTEN: KEY_LISTEN;
 
     // LEDs
-    pinMode(LED_STREAM, OUTPUT); // active low
     pinMode(LED_WIFI, OUTPUT);   // active low
     
     digitalWrite(LED_STREAM, HIGH);
@@ -146,7 +212,7 @@ void AudioKit::updateColors(int colors)
 {
     // turn off LEDs
     /// digitalWrite(LED_STREAM, HIGH);
-    indicator_light->setState(ON);
+    indicator_light->setState(PULSING);
 
     digitalWrite(LED_WIFI, HIGH);
 
@@ -198,24 +264,9 @@ void AudioKit::InitI2SSpeakerOrMic(int mode)
 
     err += i2s_driver_install(SPEAKER_I2S_NUMBER, &i2s_config, 0, NULL);
 
-    i2s_pin_config_t tx_pin_config;
+    const i2s_pin_config_t* tx_pin_config_p;
 
-    if (is_es)
-    {
-        tx_pin_config.bck_io_num = ES_CONFIG_I2S_BCK_PIN;
-        tx_pin_config.ws_io_num = ES_CONFIG_I2S_LRCK_PIN;
-        tx_pin_config.data_out_num = ES_CONFIG_I2S_DATA_PIN;
-        tx_pin_config.data_in_num = ES_CONFIG_I2S_DATA_IN_PIN;
-    }
-    else
-    {
-        tx_pin_config.bck_io_num = CONFIG_I2S_BCK_PIN;
-        tx_pin_config.ws_io_num = CONFIG_I2S_LRCK_PIN;
-        tx_pin_config.data_out_num = CONFIG_I2S_DATA_PIN;
-        tx_pin_config.data_in_num = CONFIG_I2S_DATA_IN_PIN;
-    }
-
-    err += i2s_set_pin(SPEAKER_I2S_NUMBER, &tx_pin_config);
+    err += i2s_set_pin(SPEAKER_I2S_NUMBER, &(a1s_pinouts[variant].i2s));
 
     if (is_es)
     {        

--- a/PlatformIO/src/devices/M5AtomEcho.hpp
+++ b/PlatformIO/src/devices/M5AtomEcho.hpp
@@ -17,10 +17,10 @@ class M5AtomEcho : public Device
 public:
   M5AtomEcho();
   void init();
-  void animate(int colors, int mode);
-  void animateBlinking(int colors);
-  void animatePulsing(int colors);
-  void updateColors(int colors);
+  void animate(StateColors colors, int mode);
+  void animateBlinking(StateColors colors);
+  void animatePulsing(StateColors colors);
+  void updateColors(StateColors colors);
   void updateBrightness(int brightness);
   void setReadMode();
   void setWriteMode(int sampleRate, int bitDepth, int numChannels);
@@ -57,7 +57,7 @@ bool M5AtomEcho::isHotwordDetected() {
   return M5.Btn.isPressed();
 }
 
-void M5AtomEcho::updateColors(int colors)
+void M5AtomEcho::updateColors(StateColors colors)
 {
   //Red and Green seem to be switched, we also need to map the white
   float alpha = 0.6 * (1.0 - (1.0 - ColorMap[colors][3]) * (1.0 - ColorMap[colors][3]));
@@ -73,7 +73,7 @@ void M5AtomEcho::updateBrightness(int brightness) {
   M5AtomEcho::brightness = 0;
 }
 
-void M5AtomEcho::animate(int colors, int mode) {
+void M5AtomEcho::animate(StateColors colors, int mode) {
   switch (mode)
   {
   case AnimationMode::BLINK:
@@ -87,7 +87,7 @@ void M5AtomEcho::animate(int colors, int mode) {
   }
 }
 
-void M5AtomEcho::animatePulsing(int colors) {
+void M5AtomEcho::animatePulsing(StateColors colors) {
   currentMillis = millis();
   if (currentMillis - startMillis > 5) {
     if (M5AtomEcho::pulse > M5AtomEcho::brightness) { directionDown = true; }
@@ -99,7 +99,7 @@ void M5AtomEcho::animatePulsing(int colors) {
   }
 }
 
-void M5AtomEcho::animateBlinking(int colors) {
+void M5AtomEcho::animateBlinking(StateColors colors) {
   currentMillis = millis();
   if (currentMillis - startMillis > 300) {
     M5.dis.setBrightness(ledsOn ? M5AtomEcho::brightness : 0);

--- a/PlatformIO/src/devices/MatrixVoice.hpp
+++ b/PlatformIO/src/devices/MatrixVoice.hpp
@@ -38,11 +38,11 @@ class MatrixVoice : public Device
 public:
   MatrixVoice();
   void init();
-  void animate(int colors, int mode);
-  void animateRunning(int colors);
-  void animateBlinking(int colors);
-  void animatePulsing(int colors);
-  void updateColors(int colors);
+  void animate(StateColors colors, int mode);
+  void animateRunning(StateColors colors);
+  void animateBlinking(StateColors colors);
+  void animatePulsing(StateColors colors);
+  void updateColors(StateColors colors);
   void updateBrightness(int brightness);
   void muteOutput(bool mute);
   void setVolume(uint16_t volume);
@@ -67,7 +67,7 @@ private:
   void playBytes(int16_t* input, uint32_t length);
   void interleave(const int16_t * in_L, const int16_t * in_R, int16_t * out, const size_t num_samples);
   bool FIFOFlush();
-  void updateColors(int colors, bool usePulse);
+  void updateColors(StateColors colors, bool usePulse);
   void SetPCMSamplingFrequency(uint16_t PCM_constant);
   uint16_t GetFIFOStatus();
   int fifoSize = 4096;
@@ -116,7 +116,7 @@ void MatrixVoice::updateBrightness(int brightness) {
   MatrixVoice::pulse = brightness * 90 / 100 + 10;
 }
 
-void MatrixVoice::animate(int colors, int mode) {
+void MatrixVoice::animate(StateColors colors, int mode) {
   switch (mode)
   {
   case AnimationMode::RUN:
@@ -133,7 +133,7 @@ void MatrixVoice::animate(int colors, int mode) {
   }
 }
 
-void MatrixVoice::animateRunning(int colors) {
+void MatrixVoice::animateRunning(StateColors colors) {
   currentMillis = millis();
   if (currentMillis - startMillis > 10) {
     int r = ColorMap[colors][0];
@@ -157,7 +157,7 @@ void MatrixVoice::animateRunning(int colors) {
   }
 }
 
-void MatrixVoice::animateBlinking(int colors) {
+void MatrixVoice::animateBlinking(StateColors colors) {
   currentMillis = millis();
   if (currentMillis - startMillis > 300) {
     MatrixVoice::pulse = ledsOn ? MatrixVoice::brightness : 0;
@@ -167,7 +167,7 @@ void MatrixVoice::animateBlinking(int colors) {
   }
 }
 
-void MatrixVoice::animatePulsing(int colors) {
+void MatrixVoice::animatePulsing(StateColors colors) {
   currentMillis = millis();
   if (currentMillis - startMillis > 5) {
     if (MatrixVoice::pulse > MatrixVoice::brightness) { directionDown = true; }
@@ -178,7 +178,7 @@ void MatrixVoice::animatePulsing(int colors) {
   }
 }
 
-void MatrixVoice::updateColors(int colors, bool usePulse) {
+void MatrixVoice::updateColors(StateColors colors, bool usePulse) {
   int r = ColorMap[colors][0];
   int g = ColorMap[colors][1];
   int b = ColorMap[colors][2];
@@ -201,7 +201,7 @@ void MatrixVoice::updateColors(int colors, bool usePulse) {
   everloop.Write(&image1d);
 }
 
-void MatrixVoice::updateColors(int colors) {
+void MatrixVoice::updateColors(StateColors colors) {
   updateColors(colors, false);
 }
 

--- a/PlatformIO/src/devices/TAudio.hpp
+++ b/PlatformIO/src/devices/TAudio.hpp
@@ -41,7 +41,7 @@ class TAudio : public Device {
   public:
     TAudio();
     void init();
-    void updateColors(int colors);
+    void updateColors(StateColors colors);
     void updateBrightness(int brightness);
     void setReadMode();
     void setWriteMode(int sampleRate, int bitDepth, int numChannels);
@@ -133,7 +133,7 @@ void TAudio::InitI2S() {
   return;
 }
 
-void TAudio::updateColors(int colors) {
+void TAudio::updateColors(StateColors colors) {
   strip.ClearTo(RgbColor(RgbwColor(ColorMap[colors][0],ColorMap[colors][1],ColorMap[colors][2],ColorMap[colors][3])).Dim(brightness));
   strip.Show();
 }

--- a/PlatformIO/src/index_html.h
+++ b/PlatformIO/src/index_html.h
@@ -62,16 +62,18 @@ input::-moz-focus-inner,input::-moz-focus-outer {border: 0;}
     <div class="input-container">
       <label for="mute_input">Mute input:&nbsp;</label>
       <label class="switch">
-        <input type="checkbox" name="mute_input" %MUTE_INPUT%>
+        <input type="checkbox" name="mute_input" %MUTE_INPUT% value="on">
         <span class="slider round"></span>
+        <input type="hidden" name="mute_input" value="off"/> 
       </label>
     </div>
     <div class="input-container">
       <label for="mute_output">Mute output:&nbsp;</label>
       <label class="switch">
-        <input type="checkbox" name="mute_output" %MUTE_OUTPUT%>
+        <input type="checkbox" name="mute_output" %MUTE_OUTPUT% value="on">
         <span class="slider round"></span>
       </label>
+      <input type="hidden" name="mute_output" value="off"/> 
     </div>
     <div class="input-container">
       <label for="amp_output">Output to:&nbsp;</label>


### PR DESCRIPTION
- web parameter handling uses single structure to handle parameters,
new parameters won't require much changes outside to generic code and
where the config information is being used
- this includes a small trick for making the mute_input/mute_output
handling easier by introducing a hidden field in the html
- named the color states enum and changed function signatures accordingly. Better support in
IDEs when writing code with a named enum
- Refactored the AudioKit pinout handling to
support the new ESP32 A1S pinout variant out in the wild.
- Changing MQTT parameters no longer requires a reboot, it switches to MQTTDisconnect and restarts the MQTT connection after reconfiguration of the respective parameters