### PR TITLE
Improved indicator light library

### DIFF
--- a/PlatformIO/lib/indicatorlight/IndicatorLight.h
+++ b/PlatformIO/lib/indicatorlight/IndicatorLight.h
@@ -1,23 +1,87 @@
-#ifndef _indicator_light_h_
-#define _indicator_light_h_
+#pragma once
+#include <math.h>
 
 enum IndicatorState
 {
     OFF,
     ON,
-    PULSING
+    PULSING,
+    BLINKING
 };
 
 class IndicatorLight
 {
+public:
+    const int BITS;
+    const int limit = (1 << BITS) - 1; 
 private:
     IndicatorState m_state;
     TaskHandle_t m_taskHandle;
 
-public:
-    IndicatorLight(int gpio);
-    void setState(IndicatorState state);
-    IndicatorState getState();
-};
+    int pulseMS = 2000;
+    const int stepDelayMS = 20; // 50 Hz update frequency
+    int steps;
+    float stepAngle;
+    bool inversePWM;
+    // current step angle
+    float angle = 0;
+    int maxBrightness = limit;
 
-#endif
+    
+    float duty = M_PI; // how long is the "on" part of the pulseMS length blinking cycle in as angle (M_PI = 50% duty).
+
+    void updateAnimation()
+    {
+
+        steps = pulseMS / stepDelayMS; 
+        stepAngle = (2 * M_PI) / steps;
+
+        // adjust to next integer step according to new step width, avoids
+        // wrong animations
+        angle = ceilf(angle / stepAngle) * stepAngle;
+    }
+
+public:
+    /**
+     * @brief Construct a new Indicator Light object
+     *
+     * @param gpio which GPIO the led is connected to
+     * @param inversePWM set to true if LED is active at LOW output level
+     * @param _BITS number of bits for pwm controller, up to 16 is permitted, 12 is default
+     */
+    IndicatorLight(int gpio, bool inversePWM = false, int _BITS = 12);
+
+    void setState(IndicatorState state) 
+    {
+        m_state = state;
+        xTaskNotify(m_taskHandle, 1, eSetBits);
+    }
+
+
+    IndicatorState getState() 
+    {
+        return m_state;
+    }
+
+    void setPulseTime(int pulseMS)
+    {
+        this->pulseMS = pulseMS;
+        updateAnimation();
+    }
+
+    float getStepAngle() { return stepAngle; }
+    int getStepDelayMS() { return stepDelayMS; };
+    bool getInversePWM() { return inversePWM; }
+
+    /**
+     * @brief Get the current animation angle step (1 animation cycle = 2 * PI), each call
+     * increments returned angle  by stepAngle until a value > 2 * PI is reached, then it will start again.
+     * 
+     * @return float 
+     */
+    float getAngle();
+    int getMaxBrightness() { return maxBrightness; }
+    void setMaxBrightness(int mb) { maxBrightness=mb;}
+    void setDutyPercent(float percentOn = 50) { duty = percentOn * (2*M_PI) /100.0; }
+    int getDutyAngle() { return duty; }
+};

--- a/PlatformIO/src/devices/Inmp441Max98357a.hpp
+++ b/PlatformIO/src/devices/Inmp441Max98357a.hpp
@@ -40,9 +40,10 @@ class Inmp441Max98357a : public Device
     bool readAudio(uint8_t *data, size_t size);
     void setWriteMode(int sampleRate, int bitDepth, int numChannels);
     void writeAudio(uint8_t *data, size_t size, size_t *bytes_written);
-    IndicatorLight *indicator_light = new IndicatorLight(LED_FLASH);
+    IndicatorLight* indicator_light = new IndicatorLight(LED_FLASH);
 
     int numAmpOutConfigurations() { return 1; };
+    void updateBrightness(int brightness);
     
   private:
     char* i2s_read_buff = (char*) calloc(I2S_READ_LEN, sizeof(char));
@@ -126,19 +127,44 @@ void Inmp441Max98357a::init() {
 
 void Inmp441Max98357a::updateColors(int colors)
 {
-    indicator_light->setState(OFF);
     switch (colors)
     {
     case COLORS_HOTWORD:
+        // very slow pulsing of LED
+        indicator_light->setPulseTime(4000);
         indicator_light->setState(PULSING);
+        break;
     case COLORS_WIFI_CONNECTED:
+        // quick flashing of LED
+        indicator_light->setDutyPercent(50);
+        indicator_light->setPulseTime(1000);
+        indicator_light->setState(BLINKING);
         break;
     case COLORS_WIFI_DISCONNECTED:
-        break;
+        // slower flashing of LED
+        indicator_light->setDutyPercent(25);
+        indicator_light->setPulseTime(2000);
+        indicator_light->setState(BLINKING);
+        break;    
     case COLORS_IDLE:
+        // all lights are off
+        indicator_light->setState(OFF);
+        break;
+    case COLORS_ERROR:
+        // very quick blinking of LED
+        indicator_light->setDutyPercent(25);
+        indicator_light->setPulseTime(500);
+        indicator_light->setState(BLINKING);
         break;
     case COLORS_OTA:
+        // very quick pulsing of LED
+        indicator_light->setPulseTime(500);
+        indicator_light->setState(PULSING);
         break;
+    case COLORS_TTS:
+        indicator_light->setState(ON);
+        break;
+
     }
 };
 
@@ -169,3 +195,8 @@ bool Inmp441Max98357a::readAudio(uint8_t *data, size_t size) {
     }
     return true;
 }
+
+void Inmp441Max98357a::updateBrightness(int brightness)
+{
+      indicator_light->setMaxBrightness((brightness*indicator_light->limit)/100);
+} 


### PR DESCRIPTION
[PR has no impact on other devices not using the IndicatorLight]

IndicatorLight now
- supports blink mode with variable duty cyle (i.e. ratio between on/off)
- supports setting the pulse and blink cycle duration
- permits setting of maximum brightness
- handles low and high active leds (defined in constructor)
- supports variable PWM resolution (now uses 12 bits as default)

LED pattern in AudioKit nd Inmpa441Max98357 devices now make use of
the new capabilities to map all states to LED patterns and also provide
brightness setting capabilities.
