### PR TITLE
Code for #86 Key Press Only Activation Option

### DIFF
--- a/PlatformIO/src/General.hpp
+++ b/PlatformIO/src/General.hpp
@@ -505,8 +505,7 @@ void loadConfiguration(const char *filename, Config &config) {
     config.amp_output = doc.getMember("amp_output").as<int>();
     config.brightness = doc.getMember("brightness").as<int>();
     config.hotword_brightness = doc.getMember("hotword_brightness").as<int>();
-    //config.hotword_detection = doc.getMember("hotword_detection").as<int>();
-    config.hotword_detection = 1;
+    config.hotword_detection = doc.getMember("hotword_detection").as<int>();
     config.volume = doc.getMember("volume").as<int>();
     config.gain = doc.getMember("gain").as<int>();
     config.animation = doc.getMember("animation").as<int>();

--- a/PlatformIO/src/Satellite.cpp
+++ b/PlatformIO/src/Satellite.cpp
@@ -232,7 +232,7 @@ void loop() {
   }
 
   // unless we are not connected, reconnect now using new settings
-  if (doReconnect && fsm::is_in_state<MQTTDisconnected>() == false && fsm::is_in_state<WifiDisconnected>() == false ) 
+  if (doReconnect) 
   {
     send_event(MQTTDisconnectedEvent());
   }

--- a/PlatformIO/src/index_html.h
+++ b/PlatformIO/src/index_html.h
@@ -91,6 +91,13 @@ input::-moz-focus-inner,input::-moz-focus-outer {border: 0;}
       </div>
     </div>
     <div class="input-container">
+      <label for="hotword_detection">Activation:&nbsp;</label>
+      <select name="hotword_detection">
+        <option value="0" %HW_LOCAL%>Key Press Only</option>
+        <option value="1" %HW_REMOTE%>Remote Hotword Detection</option>
+      </select>
+    </div>
+    <div class="input-container">
       <label for="brightness">Brightness:&nbsp;</label>
       <div class="range-slider">
         <input type="range" min="0" max="100" step="5" value="%BRIGHTNESS%" class="range-slider__range" name="brightness">


### PR DESCRIPTION
[PR has no impact on other devices not using the IndicatorLight]

IndicatorLight now
- supports blink mode with variable duty cyle (i.e. ratio between on/off)
- supports setting the pulse and blink cycle duration
- permits setting of maximum brightness
- handles low and high active leds (defined in constructor)
- supports variable PWM resolution (now uses 12 bits as default)

LED pattern in AudioKit nd Inmpa441Max98357 devices now make use of
the new capabilities to map all states to LED patterns and also provide
brightness setting capabilities.
