### PR TITLE
AudioKit LED and Key pins changed, doc update

### DIFF
--- a/PlatformIO/src/devices/AudioKit.hpp
+++ b/PlatformIO/src/devices/AudioKit.hpp
@@ -9,10 +9,12 @@
 #include "ES8388Control.h"
 
 // there are multiple versions of the new ESP32-A1S in the wild
-// with different pinouts for I2S and I2C
+// with different pinouts for I2S and I2C and different audio controllers
 // see https://github.com/Ai-Thinker-Open/ESP32-A1S-AudioKit/issues/26
 //
-// This is the newer version which brings back usable keys 4 to 6: https://github.com/Ai-Thinker-Open/ESP32-A1S-AudioKit/files/7387472/esp32-a1s_v2.3-20210508.1.pdf
+// Link to the newer version with ES8388 which brings back usable keys 4 to 6: 
+// https://github.com/Ai-Thinker-Open/ESP32-A1S-AudioKit/files/7387472/esp32-a1s_v2.3-20210508.1.pdf
+
 
 enum A1SVariant
 {
@@ -62,7 +64,7 @@ const A1S_Pinouts a1s_pinouts[] = {
         },
         .i2c = { .sda = 33, .scl = 32 }
     },
-    // ESP32-A1S AC101 varian
+    // ESP32-A1S AC101 variant
     {
         .label = "AC101",
         .variant = A1SVariant::AC101_V1,
@@ -82,8 +84,8 @@ const A1S_Pinouts a1s_pinouts[] = {
 #define GPIO_SEL_PA_EN GPIO_SEL_21
 
 // Audiokit LEDs
-#define LED_D4 GPIO_NUM_19
-#define LED_D5 GPIO_NUM_22
+#define LED_D4 GPIO_NUM_22
+#define LED_D5 GPIO_NUM_19
 // alias
 #define LED_WIFI LED_D5
 #define LED_STREAM LED_D4
@@ -97,7 +99,7 @@ const A1S_Pinouts a1s_pinouts[] = {
 #define KEY6_GPIO GPIO_NUM_5  // do not use on A1S V2.3 with initial pinout -> I2S
 
 // alias
-#define KEY_LISTEN KEY3_GPIO
+#define KEY_LISTEN KEY1_GPIO
 #define ES_KEY_LISTEN KEY1_GPIO
 
 //#define KEY_VOL_UP KEYx_GPIO
@@ -127,9 +129,11 @@ public:
 
     bool isHotwordDetected();
 
-    int numAmpOutConfigurations() { return 3; };
+    int numAmpOutConfigurations() { return 3;
+    };
     void updateBrightness(int brightness);
 
+    const i2s_pin_config_t& getPinConfig() { return a1s_pinouts[variant].i2s; }
 private:
     void InitI2SSpeakerOrMic(int mode);
     AC101 ac;
@@ -277,7 +281,7 @@ void AudioKit::InitI2SSpeakerOrMic(int mode)
 
     err += i2s_driver_install(SPEAKER_I2S_NUMBER, &i2s_config, 0, NULL);
 
-    err += i2s_set_pin(SPEAKER_I2S_NUMBER, &(a1s_pinouts[variant].i2s));
+    err += i2s_set_pin(SPEAKER_I2S_NUMBER, &getPinConfig());
 
     if (is_es)
     {        

--- a/PlatformIO/src/devices/Inmp441Max98357a.hpp
+++ b/PlatformIO/src/devices/Inmp441Max98357a.hpp
@@ -29,7 +29,6 @@
 #define I2S_READ_LEN     512
 // LEDs
 #define LED_FLASH 4
-#define LED 33
 
 class Inmp441Max98357a : public Device
 {
@@ -38,8 +37,10 @@ class Inmp441Max98357a : public Device
     void init();
     void updateColors(int colors);
     bool readAudio(uint8_t *data, size_t size);
+    
     void setWriteMode(int sampleRate, int bitDepth, int numChannels);
     void writeAudio(uint8_t *data, size_t size, size_t *bytes_written);
+
     IndicatorLight* indicator_light = new IndicatorLight(LED_FLASH);
 
     int numAmpOutConfigurations() { return 1; };

--- a/audiokit.md
+++ b/audiokit.md
@@ -3,3 +3,30 @@
 - Connect the Audio Kit to your computer via USB, like a regular esp32
 - First flash, set "upload" as method under the OTA section in the settings.ini. After that you can set it to "ota" as well
 - Build and flash the project with PlatformIO, for example run `pio run --target upload` from the commandline
+
+# Supported features
+- All known hardware variants (AC101, ES8388 pinout variants 1 and 2) supported
+- Optional command activation by key press on key 1
+- Single LED state notification using D4
+- LED brightness control
+- Configurable output to headphone jack and/or speakers
+
+# Unsupported features
+- Configurable LED animations 
+- Configurable microphone input gain
+
+# LED Notification
+The device indicates its various states through a single LED using different patterns.
+
+| LED                             | State                                     |
+|---------------------------------|-------------------------------------------|
+| Slow flashing (2s cycle)        | WiFi not connected / startup              |
+| Fast flashing (1s cycle)        | WiFi connected, but no MQTT connection    |
+| Off                             | Ready, listening for hotword / activation |
+| Slow pulsing  (4s cycle)        | Listening to voice commands               |
+| Steady on                       | Speech output from Rhasspy                |
+| Very fast flashing (0.5s cycle) | Voice command not recognized              |  
+| Fast pulsing (0.5s cycle)       | Over-the-air update in progress           |
+
+# Known issues
+- AC101 based boards may not go back easily into hotword detection after voice command, they keep listening for voice commands. Reduce VAD sensistivity (i.e. set VAD to a higher value) in Rhasspy Speech to Text settings to mitigate.


### PR DESCRIPTION
- The indicator LED is now the LED connected to
pin 22. It is still named D4 in the code, but it was
using the "wrong" pin 19,  which in fact is
connected to the LED named D5 in schematic
- All variants of the AudioKIt now use Key 1 for key
press activation (formerly AC101 was using Key 3).
- Updated AudioKit device readme to describe
relevant device specific information