### PR TITLE
Add support for volume control via Rhasspy.

### DIFF
--- a/PlatformIO/src/General.hpp
+++ b/PlatformIO/src/General.hpp
@@ -82,6 +82,7 @@ std::string restartTopic = config.siteid + std::string("/restart");
 std::string sayTopic = "hermes/tts/say";
 std::string sayFinishedTopic = "hermes/tts/sayFinished";
 std::string errorTopic = "hermes/nlu/intentNotRecognized";
+std::string setVolumeTopic = "rhasspy/audioServer/setVolume";
 AsyncMqttClient asyncClient; 
 WiFiClient net;
 PubSubClient audioServer(net); 


### PR DESCRIPTION
Allows to control the volume with the Rhasspy WebUI.
![image](https://user-images.githubusercontent.com/2230104/156935493-77a99f9a-19a5-4b35-93f9-db7a1fe629fd.png)
This is redundant to the `<site-id>/audio` topic though.

Tested on an ESP32-Audio-Kit with Rhasspy 2.5.10.